### PR TITLE
Updated tests to work with expresso 0.7.0

### DIFF
--- a/test/buffer.js
+++ b/test/buffer.js
@@ -2,10 +2,11 @@
 // Test CSV - Copyright David Worms <open@adaltas.com> (MIT Licensed)
 
 var fs = require('fs'),
+	assert = require('assert'),
 	csv = require('csv');
 
 module.exports = {
-	'Buffer smaller than in': function(assert){
+	'Buffer smaller than in': function(){
 		csv()
 		.fromPath(__dirname+'/buffer/smaller.in',{
 			bufferSize: 1024
@@ -24,7 +25,7 @@ module.exports = {
 			fs.unlink(__dirname+'/buffer/smaller.tmp');
 		});
 	},
-	'Buffer same as in': function(assert){
+	'Buffer same as in': function(){
 		csv()
 		.fromPath(__dirname+'/buffer/same.in',{
 			bufferSize: 1024

--- a/test/columns.js
+++ b/test/columns.js
@@ -2,10 +2,11 @@
 // Test CSV - Copyright David Worms <open@adaltas.com> (MIT Licensed)
 
 var fs = require('fs'),
+	assert = require('assert'),
 	csv = require('csv');
 
 module.exports = {
-	'Test columns in true': function(assert){
+	'Test columns in true': function(){
 		// Note: if true, columns are expected to be in first line
 		csv()
 		.fromPath(__dirname+'/columns/in_true.in',{
@@ -31,7 +32,7 @@ module.exports = {
 			fs.unlink(__dirname+'/columns/in_true.tmp');
 		});
 	},
-	'Test columns in named': function(assert){
+	'Test columns in named': function(){
 		// Note: if true, columns are expected to be in first line
 		csv()
 		.fromPath(__dirname+'/columns/in_named.in',{
@@ -61,7 +62,7 @@ module.exports = {
 			fs.unlink(__dirname+'/columns/in_named.tmp');
 		});
 	},
-	'Test columns out named': function(assert){
+	'Test columns out named': function(){
 		// Note: if true, columns are expected to be in first line
 		csv()
 		.fromPath(__dirname+'/columns/out_named.in')

--- a/test/delimiter.js
+++ b/test/delimiter.js
@@ -2,10 +2,11 @@
 // Test CSV - Copyright David Worms <open@adaltas.com> (MIT Licensed)
 
 var fs = require('fs'),
+	assert = require('assert'),
 	csv = require('csv');
 
 module.exports = {
-	'Test empty value': function(assert){
+	'Test empty value': function(){
 		csv()
 		.fromPath(__dirname+'/delimiter/empty_value.in')
 		.toPath(__dirname+'/delimiter/empty_value.tmp')

--- a/test/escape.js
+++ b/test/escape.js
@@ -2,11 +2,12 @@
 // Test CSV - Copyright David Worms <open@adaltas.com> (MIT Licensed)
 
 var fs = require('fs'),
+	assert = require('assert'),
 	csv = require('csv');
 
 module.exports = {
 	// Note: we only escape quote and escape character
-	'Test default': function(assert){
+	'Test default': function(){
 		csv()
 		.fromPath(__dirname+'/escape/default.in',{
 			escape: '"'
@@ -26,7 +27,7 @@ module.exports = {
 			fs.unlink(__dirname+'/escape/default.tmp');
 		});
 	},
-	'Test backslash': function(assert){
+	'Test backslash': function(){
 		csv()
 		.fromPath(__dirname+'/escape/backslash.in',{
 			escape: '\\'

--- a/test/fromto.js
+++ b/test/fromto.js
@@ -2,10 +2,11 @@
 // Test CSV - Copyright David Worms <open@adaltas.com> (MIT Licensed)
 
 var fs = require('fs'),
+	assert = require('assert'),
 	csv = require('csv');
 
 module.exports = {
-	'Test fs stream': function(assert){
+	'Test fs stream': function(){
 		csv()
 		.fromStream(fs.createReadStream(__dirname+'/fromto/sample.in',{flags:'r'}))
 		.toStream(fs.createWriteStream(__dirname+'/fromto/sample.tmp',{flags:'w'}))
@@ -18,7 +19,7 @@ module.exports = {
 			fs.unlink(__dirname+'/fromto/sample.tmp');
 		});
 	},
-	'Test string without destination': function(assert){
+	'Test string without destination': function(){
 		csv()
 		.from(fs.readFileSync(__dirname+'/fromto/sample.in').toString())
 		.on('data',function(data,index){
@@ -33,7 +34,7 @@ module.exports = {
 			assert.strictEqual(2,count);
 		});
 	},
-	'Test string to stream': function(assert){
+	'Test string to stream': function(){
 		csv()
 		.from(fs.readFileSync(__dirname+'/fromto/string_to_stream.in').toString())
 		.toPath(__dirname+'/fromto/string_to_stream.tmp')
@@ -54,7 +55,7 @@ module.exports = {
 			fs.unlink(__dirname+'/fromto/string_to_stream.tmp');
 		});
 	},
-	'Test array to stream': function(assert){
+	'Test array to stream': function(){
 		// note: destination line breaks is windows styled because we can't guess it
 		var data = [
 			["20322051544","1979.0","8.8017226E7","ABC","45","2000-01-01"],

--- a/test/lineBreaks.js
+++ b/test/lineBreaks.js
@@ -2,10 +2,11 @@
 // Test CSV - Copyright David Worms <open@adaltas.com> (MIT Licensed)
 
 var fs = require('fs'),
+	assert = require('assert'),
 	csv = require('csv');
 
 module.exports = {
-	'Test line breaks custom': function(assert){
+	'Test line breaks custom': function(){
 		csv()
 		.fromPath(__dirname+'/lineBreaks/lineBreaks.in',{
 		})
@@ -21,7 +22,7 @@ module.exports = {
 			fs.unlink(__dirname+'/lineBreaks/custom.tmp');
 		});
 	},
-	'Test line breaks unix': function(assert){
+	'Test line breaks unix': function(){
 		csv()
 		.fromPath(__dirname+'/lineBreaks/lineBreaks.in',{
 		})
@@ -37,7 +38,7 @@ module.exports = {
 			fs.unlink(__dirname+'/lineBreaks/unix.tmp');
 		});
 	},
-	'Test line breaks unicode': function(assert){
+	'Test line breaks unicode': function(){
 		csv()
 		.fromPath(__dirname+'/lineBreaks/lineBreaks.in',{
 		})
@@ -53,7 +54,7 @@ module.exports = {
 			fs.unlink(__dirname+'/lineBreaks/unicode.tmp');
 		});
 	},
-	'Test line breaks mac': function(assert){
+	'Test line breaks mac': function(){
 		csv()
 		.fromPath(__dirname+'/lineBreaks/lineBreaks.in',{
 		})
@@ -69,7 +70,7 @@ module.exports = {
 			fs.unlink(__dirname+'/lineBreaks/mac.tmp');
 		});
 	},
-	'Test line breaks windows': function(assert){
+	'Test line breaks windows': function(){
 		csv()
 		.fromPath(__dirname+'/lineBreaks/lineBreaks.in',{
 		})

--- a/test/quotes.js
+++ b/test/quotes.js
@@ -2,10 +2,11 @@
 // Test CSV - Copyright David Worms <open@adaltas.com> (MIT Licensed)
 
 var fs = require('fs'),
+	assert = require('assert'),
 	csv = require('csv');
 
 module.exports = {
-	'Test regular quotes': function(assert){
+	'Test regular quotes': function(){
 		csv()
 		.fromPath(__dirname+'/quotes/regular.in',{
 		})
@@ -19,7 +20,7 @@ module.exports = {
 			fs.unlink(__dirname+'/quotes/regular.tmp');
 		});
 	},
-	'Test quotes with delimiter': function(assert){
+	'Test quotes with delimiter': function(){
 		csv()
 		.fromPath(__dirname+'/quotes/delimiter.in',{
 		})
@@ -33,7 +34,7 @@ module.exports = {
 			fs.unlink(__dirname+'/quotes/delimiter.tmp');
 		});
 	},
-	'Test quotes inside field': function(assert){
+	'Test quotes inside field': function(){
 		csv()
 		.fromPath(__dirname+'/quotes/in_field.in',{
 		})
@@ -47,7 +48,7 @@ module.exports = {
 			fs.unlink(__dirname+'/quotes/in_field.tmp');
 		});
 	},
-	'Test empty value': function(assert){
+	'Test empty value': function(){
 		csv()
 		.fromPath(__dirname+'/quotes/empty_value.in',{
 			quote: '"',
@@ -62,7 +63,7 @@ module.exports = {
 			fs.unlink(__dirname+'/quotes/empty_value.tmp');
 		});
 	},
-	'Test quoted quote': function(assert){
+	'Test quoted quote': function(){
 		csv()
 		.fromPath(__dirname+'/quotes/quoted.in',{
 			quote: '"',

--- a/test/transform.js
+++ b/test/transform.js
@@ -2,10 +2,11 @@
 // Test CSV - Copyright David Worms <open@adaltas.com> (MIT Licensed)
 
 var fs = require('fs'),
+	assert = require('assert'),
 	csv = require('csv');
 
 module.exports = {
-	'Test reorder fields': function(assert){
+	'Test reorder fields': function(){
 		var count = 0;
 		csv()
 		.fromPath(__dirname+'/transform/reorder.in')
@@ -25,7 +26,7 @@ module.exports = {
 			fs.unlink(__dirname+'/transform/reorder.tmp');
 		});
 	},
-	'Test empty': function(assert){
+	'Test empty': function(){
 		var count = 0;
 		csv()
 		.fromPath(__dirname+'/transform/empty.in')
@@ -44,7 +45,7 @@ module.exports = {
 			fs.unlink(__dirname+'/transform/empty.tmp');
 		});
 	},
-	'Test return object': function(assert){
+	'Test return object': function(){
 		// we don't define columns
 		// recieve and array and return an object
 		// also see the columns test
@@ -63,7 +64,7 @@ module.exports = {
 			fs.unlink(__dirname+'/transform/object.tmp');
 		});
 	},
-	'Test return string': function(assert){
+	'Test return string': function(){
 		csv()
 		.fromPath(__dirname+'/transform/string.in')
 		.toPath(__dirname+'/transform/string.tmp')
@@ -79,7 +80,7 @@ module.exports = {
 			fs.unlink(__dirname+'/transform/string.tmp');
 		});
 	},
-	'Test types': function(assert){
+	'Test types': function(){
 		// Test date, int and float
 		csv()
 		.fromPath(__dirname+'/transform/types.in')


### PR DESCRIPTION
Expresso 0.7.0 removed `assert` from test function signature, updated to use Removed `require('assert')`
