### PR TITLE
Fallback writeOptions.lineBreak not consistent

### DIFF
--- a/lib/csv.js
+++ b/lib/csv.js
@@ -414,7 +414,7 @@ module.exports = function(){
                 line.splice(csv.writeOptions.columns.length);
             }
             if(line instanceof Array){
-                var newLine = state.countWriten ? csv.writeOptions.lineBreaks || "\r" : '';
+                var newLine = state.countWriten ? csv.writeOptions.lineBreaks || "\r\n" : '';
                 for(var i=0; i<line.length; i++){
                     var field = line[i];
                     if(typeof field === 'string'){

--- a/readme.md
+++ b/readme.md
@@ -145,7 +145,7 @@ Options are:
     Display the column names on the first line if the columns option is provided.
 
 -   *lineBreaks*    
-    String used to delimit record rows or a special value; special values are 'auto', 'unix', 'mac', 'windows', 'unicode'; default to 'auto' (discovered in source).
+    String used to delimit record rows or a special value; special values are 'auto', 'unix', 'mac', 'windows', 'unicode'; default to 'auto' (discovered in source or 'windows' if no source is specified).
     
 -   *flags*    
     Default to 'w', 'w' to create or overwrite an file, 'a' to append to a file. Apply when using the `toPath` method.


### PR DESCRIPTION
When using `csv` without a source (only to generate a CSV output), the `lineBreaks` option [falls back](https://github.com/wdavidw/node-csv-parser/blob/b8be8163badb857f3ea1f8066a7b38a248f214ed/lib/csv.js#L417) to `\r` (old mac).

When an `Array` source is used, `lineBreaks` [falls back](https://github.com/wdavidw/node-csv-parser/blob/b8be8163badb857f3ea1f8066a7b38a248f214ed/lib/csv.js#L77) to `\r\n` (windows).

This change makes this consistent to `\r\n'. I would have used`\n` but now we are getting philosophical...

BTW, mac today is also using `\r` since it is now a UNIX variant (BSD), so I'm not sure using the term `mac` makes a lot of sense.
