### PR TITLE
Headers are not emitted on sourceless writes

### DIFF
--- a/lib/csv.js
+++ b/lib/csv.js
@@ -134,6 +134,9 @@ module.exports = function(){
             state.line = data;
             return flush();
         }
+        if(state.count === 0 && csv.writeOptions.header === true){
+            write(csv.writeOptions.columns || csv.readOptions.columns);
+        }
         write(data, preserve);
         if(!transforming && !preserve){
             state.count++;

--- a/test/write.coffee
+++ b/test/write.coffee
@@ -106,6 +106,18 @@ describe 'write', ->
         for i in [0...1000]
             test.write ['Test '+i, i, '"']
         test.end()
+    it 'should emit header even without a source', (next) ->
+        test = csv()
+        .toPath( "#{__dirname}/write/write_sourceless.tmp", 
+            columns: [ 'col1', 'col2' ], 
+            header: true, 
+            lineBreaks: 'unix' )
+        .on 'end', ->
+            expect = fs.readFileSync("#{__dirname}/write/write_sourceless.out").toString()
+            result = fs.readFileSync("#{__dirname}/write/write_sourceless.tmp").toString()
+            result.should.eql expect
+            fs.unlink "#{__dirname}/write/write_sourceless.tmp", next
 
-
-
+        test.write col1: 'foo1', col2: 'goo1'
+        test.write col1: 'foo2', col2: 'goo2'
+        test.end()

--- a/test/write/write_sourceless.out
+++ b/test/write/write_sourceless.out
@@ -1,0 +1,3 @@
+col1,col2
+foo1,goo1
+foo2,goo2


### PR DESCRIPTION
If csv is used without a source and `{header:true}`, headers are not
emitted.
