### PR TITLE
pause read stream

### DIFF
--- a/lib/csv.js
+++ b/lib/csv.js
@@ -213,7 +213,11 @@ be sent until resume() is called.
 
 
 CSV.prototype.pause = function() {
-  return this.paused = true;
+  if (this.readStream != null) {
+    return this.readStream.pause();
+  } else {
+    return this.paused = true;
+  }
 };
 
 /*
@@ -222,13 +226,17 @@ CSV.prototype.pause = function() {
 ----------
 
 Implementation of the Readable Stream API, resuming the incoming 'data' 
-events after a pause().
+events after a pause()
 */
 
 
 CSV.prototype.resume = function() {
-  this.paused = false;
-  return this.emit('drain');
+  if (this.readStream != null) {
+    return this.readStream.resume();
+  } else {
+    this.paused = false;
+    return this.emit('drain');
+  }
 };
 
 /*

--- a/src/csv.coffee
+++ b/src/csv.coffee
@@ -206,7 +206,10 @@ be sent until resume() is called.
 
 ###
 CSV.prototype.pause = ->
-  @paused = true
+  if @readStream?
+    @readStream.pause()
+  else
+    @paused = true
 
 ###
 
@@ -214,12 +217,15 @@ CSV.prototype.pause = ->
 ----------
 
 Implementation of the Readable Stream API, resuming the incoming 'data' 
-events after a pause().
+events after a pause()
 
 ###
 CSV.prototype.resume = ->
-  @paused = false
-  @emit 'drain'
+  if @readStream?
+    @readStream.resume()
+  else
+    @paused = false
+    @emit 'drain'
 
 ###
 


### PR DESCRIPTION
I ran into an issue where pause did not seem to be pausing. This commit fixes it for stream mode. 

My client code looks basically like this:

``` javascript
inflate = zlib.createGunzip()
gzinput = fs.createReadStream bigfile

source = csv()
...
source
   .from.stream(gzinput.pipe inflate)
   .on (record) -> slowerAsyncWork()
```
