### PR TITLE
Have from stream send pause/resume advisories from csv to stream

### DIFF
--- a/lib/csv.js
+++ b/lib/csv.js
@@ -178,6 +178,7 @@ parser = require('./parser');
 transformer = require('./transformer');
 
 CSV = function() {
+  this.paused = false;
   this.readable = true;
   this.writable = true;
   this.state = state();

--- a/lib/from.js
+++ b/lib/from.js
@@ -195,13 +195,22 @@ module.exports = function(csv) {
   from.stream = function(stream, options) {
     this.options(options);
     stream.on('data', function(data) {
-      return csv.write(data.toString());
+      if (csv.writable) {
+        if (false === csv.write(data.toString())) {
+          return stream.pause();
+        }
+      }
     });
     stream.on('error', function(e) {
       return csv.error(e);
     });
     stream.on('end', function() {
       return csv.end();
+    });
+    csv.on('drain', function() {
+      if (stream.readable) {
+        return stream.resume();
+      }
     });
     csv.readStream = stream;
     return csv;

--- a/src/csv.coffee
+++ b/src/csv.coffee
@@ -170,6 +170,7 @@ parser = require './parser'
 transformer = require './transformer'
 
 CSV = ->
+  @paused = false
   # A boolean that is true by default, but turns false after an 'error' occurred, 
   # the stream came to an 'end' or the destroy function is called. 
   @readable = true

--- a/src/from.coffee
+++ b/src/from.coffee
@@ -171,11 +171,16 @@ module.exports = (csv) ->
   from.stream = (stream, options) ->
     @options options
     stream.on 'data', (data) ->
-      csv.write data.toString()
+      if csv.writable
+        if false is csv.write data.toString()
+          stream.pause()
     stream.on 'error', (e) ->
       csv.error e
     stream.on 'end', ->
       csv.end()
+    csv.on 'drain', ->
+      if stream.readable
+        stream.resume()
     csv.readStream = stream
     csv
 

--- a/test/from.coffee
+++ b/test/from.coffee
@@ -7,6 +7,7 @@ require 'coffee-script'
 fs = require 'fs'
 should = require 'should'
 csv = if process.env.CSV_COV then require '../lib-cov/csv' else require '../src/csv'
+generator = if process.env.CSV_COV then require '../lib-cov/generator' else require '../src/generator'
 
 describe 'from', ->
 
@@ -42,6 +43,26 @@ describe 'from', ->
       .on 'record', (record) ->
         record.length.should.eql 5
       .on 'end', ->
+        next()
+
+  describe 'stream', ->
+
+    it 'should be able to pause', (next) ->
+      paused = false
+      csv()
+      .from.stream(generator(start: true, duration: 500))
+      .on 'record', (record, index) ->
+        paused.should.be.false
+        if index is 5
+          @pause()
+          @paused.should.be.true
+          paused = true
+          resume = () =>
+            paused = false
+            @resume()
+          setTimeout resume, 100
+      .on 'end', ->
+        paused.should.be.false
         next()
 
   describe 'string', ->


### PR DESCRIPTION
This is similar to #52, but includes a test and places the pause/resume proxies in the from implementation where it makes better sense. The implementation comes from node's own `lib/stream.js`. This is just a simple pause/resume implementation, a pause doesn't always cause the stream to actually stop emitting data, so after a pause, csv may continue to emit `data` and `record` events, especially while the parser is still working through the last data chunk it received. This is compliant with node's stream definitions, though.
