### PR TITLE
Defer escape parsing if next char is not in the current chunk

### DIFF
--- a/lib/csv.js
+++ b/lib/csv.js
@@ -22,7 +22,8 @@ module.exports = function(){
         quoted: false,
         commented: false,
         buffer: null,
-        bufferPosition: 0
+        bufferPosition: 0,
+        leftOver: ''
     }
     // Are we currently inside the transform callback? If so,
     // we shouldn't increment `state.count` which count provided lines
@@ -150,6 +151,9 @@ module.exports = function(){
             // return csv.emit('error', new Error('Quoted field not terminated'));
             return error(new Error('Quoted field not terminated'));
         }
+        if (state.leftOver) {
+            return csv.emit('error', new Error('Escape sequence not terminated'));
+        }
         // dump open record
         if (state.field || state.lastC === this.readOptions.delimiter || state.lastC === this.readOptions.quote) {
             if(csv.readOptions.trim || csv.readOptions.rtrim){
@@ -237,7 +241,8 @@ module.exports = function(){
      * transform is called on a new line
      */
     function parse(chars){
-        chars = '' + chars;
+        chars = '' + state.leftOver + chars;
+        state.leftOver = '';
         for (var i = 0, l = chars.length; i < l; i++) {
             var c = chars.charAt(i);
             switch (c) {
@@ -246,6 +251,12 @@ module.exports = function(){
                     if( state.commented ) break;
                     var isEscape = false;
                     if (c === csv.readOptions.escape) {
+                        // If the next char is not in the current chunk, we need to defer deciding about this escape.
+                        if (i + 1 >= l) {
+                          state.leftOver = c;
+                          break;
+                        }
+
                         // Make sure the escape is really here for escaping:
                         // if escape is same as quote, and escape is first char of a field and it's not quoted, then it is a quote
                         // next char should be an escape or a quote


### PR DESCRIPTION
If the last char of a chunk is the escape char, parsing fails.
