### PR TITLE
The example on the readme is slightly incorrect, and will result in intermittent failures.

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,9 @@ csv()
 .on('record', function(row,index){
   console.log('#'+index+' '+JSON.stringify(row));
 })
-.on('end', function(count){
+.on('close', function(count){
+  // when writing to a file, use the 'close' event
+  // the 'end' event may fire before the file has been written
   console.log('Number of lines: '+count);
 })
 .on('error', function(error){


### PR DESCRIPTION
As per the documentation in to.js, it is incorrect to rely on the 'end' event when writing to a file.  Utilize 'close' instead.
