### PR TITLE
Test against Node 0.10

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
-
 language: node_js
 node_js:
   - 0.6
   - 0.7
   - 0.8
-  - 0.9
+  - "0.10"


### PR DESCRIPTION
Since 0.9 has become the stable 0.10 branch, it should be tested with instead.
