### PR TITLE
Minor correction to the README. The 'close'-event is seemingly called 'end'.

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ csv()
 .on('record', function(row,index){
   console.log('#'+index+' '+JSON.stringify(row));
 })
-.on('close', function(count){
+.on('end', function(count){
   // when writing to a file, use the 'close' event
   // the 'end' event may fire before the file has been written
   console.log('Number of lines: '+count);


### PR DESCRIPTION
Just a minor type miss print in the README.md. Seemingly it will never trigger the 'close'-event, but the 'end'-event works just fine.
