### PR TITLE
setImmediate instead of nextTick for node >=0.10

### DIFF
--- a/src/from.coffee
+++ b/src/from.coffee
@@ -1,9 +1,11 @@
-
 fs = require 'fs'
 path = require 'path'
 fs.exists ?= path.exists
 utils = require './utils'
 Stream = require 'stream'
+timers = require 'timers'
+# Use process.nextTick when setImmediate isn't there for legacy support of node < 0.10
+nextTick = if timers.setImmediate then timers.setImmediate else process.nextTick
 
 ###
 
@@ -118,7 +120,7 @@ module.exports = (csv) ->
   ###
   from.array = (data, options) ->
     @options options
-    process.nextTick ->
+    nextTick ->
       for record in data
         csv.write record
       csv.end()
@@ -141,7 +143,7 @@ module.exports = (csv) ->
   ###
   from.string = (data, options) ->
     @options options
-    process.nextTick ->
+    nextTick ->
       # A string is handle exactly the same way as a single `write` call 
       # which is then closed. This is because the `write` function may receive
       # multiple and incomplete lines.

--- a/src/generator.coffee
+++ b/src/generator.coffee
@@ -1,6 +1,8 @@
-
 Stream = require 'stream'
 util = require 'util'
+timers = require 'timers'
+# Use process.nextTick when setImmediate isn't there for legacy support of node < 0.10
+nextTick = if timers.setImmediate then timers.setImmediate else process.nextTick
 
 ###
 
@@ -34,7 +36,7 @@ Generator = (@options = {}) ->
   @start = Date.now()
   @end = @start + @options.duration
   @readable = true
-  process.nextTick @resume.bind @ if @options.start
+  nextTick @resume.bind @ if @options.start
   @
 Generator.prototype.__proto__ = Stream.prototype
 

--- a/src/transformer.coffee
+++ b/src/transformer.coffee
@@ -1,5 +1,7 @@
-
 stream = require 'stream'
+timers = require 'timers'
+# Use process.nextTick when setImmediate isn't there for legacy support of node < 0.10
+nextTick = if timers.setImmediate then timers.setImmediate else process.nextTick
 
 ###
 Transforming data

--- a/test/columns.coffee
+++ b/test/columns.coffee
@@ -140,6 +140,7 @@ describe 'columns', ->
       , columns: ["FIELD_1", "FIELD_2"])
    
     it 'should emit new columns in output', (next) ->
+      process.maxTickDepth = 2
       csv()
       .from.string("""
         FIELD_1,FIELD_2,FIELD_3,FIELD_4,FIELD_5,FIELD_6

--- a/test/escape.coffee
+++ b/test/escape.coffee
@@ -1,4 +1,3 @@
-
 ###
 Test CSV - Copyright David Worms <open@adaltas.com> (BSD Licensed)
 ###
@@ -6,6 +5,9 @@ Test CSV - Copyright David Worms <open@adaltas.com> (BSD Licensed)
 fs = require 'fs'
 should = require 'should'
 csv = if process.env.CSV_COV then require '../lib-cov' else require '../src'
+timers = require 'timers'
+# Use process.nextTick when setImmediate isn't there for legacy support of node < 0.10
+nextTick = if timers.setImmediate then timers.setImmediate else process.nextTick
 
 describe 'escape', ->
 
@@ -53,10 +55,11 @@ describe 'escape', ->
       tick = ->
         if i < chunks.length
           self.emit 'data', chunks[i++]
-          process.nextTick tick
+          nextTick tick
         else
           self.emit 'end'
-      process.nextTick tick
+      nextTick tick
+      null # must return null, process.nextTick does but timers.setImmediate does not
     util.inherits ChunksStream, Stream
     ChunksStream.prototype.destroy = -> # ok
     data = ['"field with \\', '" inside"']
@@ -71,7 +74,3 @@ describe 'escape', ->
       records.length.should.eql 1
       records[0][0].should.eql 'field with " inside'
       next()
-
-
-
-

--- a/test/transform.coffee
+++ b/test/transform.coffee
@@ -1,4 +1,3 @@
-
 ###
 Test CSV - Copyright David Worms <open@adaltas.com> (BSD Licensed)
 ###
@@ -6,6 +5,9 @@ Test CSV - Copyright David Worms <open@adaltas.com> (BSD Licensed)
 fs = require 'fs'
 should = require 'should'
 csv = if process.env.CSV_COV then require '../lib-cov' else require '../src'
+timers = require 'timers'
+# Use process.nextTick when setImmediate isn't there for legacy support of node < 0.10
+nextTick = if timers.setImmediate then timers.setImmediate else process.nextTick
 
 describe 'transform', ->
 
@@ -200,7 +202,7 @@ describe 'transform', ->
         data.should.eql 'b1,a1\nb2,a2'
         next()
       .transform (record, index, callback) ->
-        process.nextTick ->
+        nextTick ->
           callback null, record.reverse()
 
     it 'should output the record if passed in the callback as an object', (next) ->
@@ -210,7 +212,7 @@ describe 'transform', ->
         data.should.eql 'b1,a1\nb2,a2'
         next()
       .transform (record, index, callback) ->
-        process.nextTick ->
+        nextTick ->
           callback null, a: record[1], b: record[0]
 
     it 'should skip the record if callback called without a record', (next) ->
@@ -220,7 +222,7 @@ describe 'transform', ->
         data.should.eql 'a1,b1\na3,b3'
         next()
       .transform (record, index, callback) ->
-        process.nextTick ->
+        nextTick ->
           callback null, if index % 2 is 0 then record else null
 
     it 'should run 20 transforms in parallel by default', (next) ->
@@ -230,7 +232,7 @@ describe 'transform', ->
         next()
       .transform (record, index, callback) ->
         count++
-        process.nextTick ->
+        nextTick ->
           (count <= 20).should.be.ok
           count--
           callback null, record
@@ -250,7 +252,7 @@ describe 'transform', ->
         count++
         running.should.equal 0
         running++
-        process.nextTick ->
+        nextTick ->
           running--
           running.should.equal 0
           callback null, record
@@ -271,7 +273,6 @@ describe 'transform', ->
         next()
       , newColumns:true, header:true)
       .transform (data, index, callback) ->
-        process.nextTick ->
+        nextTick ->
           data.foo = 'bar';
           callback null, data
-


### PR DESCRIPTION
You're supposed to use `setImmediate` in node >=0.10 instead of `process.nextTick`. The test cases were only passing because none of them tested on more documents than `process.maxTickDepth` (by default 1000). If you run on more documents than that, it crashes with `RangeError: maximum call stack size exceeded`.

I artificially lowered `process.maxTickDepth` in one of the test cases to generate a failing test case, then changed all instances of `process.nextTick` to use `setImmediate` where available and verified that the test cases are passing again.

I didn't submit any of the compiled js because my version of coffee-script is different than your's so there were a lot of diffs that were just white noise.
