### PR TITLE
fix csv strigifier so it does not emit inherited properties

### DIFF
--- a/lib/stringifier.js
+++ b/lib/stringifier.js
@@ -7,7 +7,8 @@ Stringifier
 Convert an array or an object into a CSV line.
 */
 
-var Stringifier;
+var Stringifier,
+  __hasProp = {}.hasOwnProperty;
 
 Stringifier = function(csv) {
   this.csv = csv;
@@ -79,6 +80,7 @@ Stringifier.prototype.stringify = function(line) {
       }
     } else {
       for (column in line) {
+        if (!__hasProp.call(line, column)) continue;
         _line.push(line[column]);
       }
     }

--- a/src/stringifier.coffee
+++ b/src/stringifier.coffee
@@ -58,7 +58,7 @@ Stringifier.prototype.stringify = (line) ->
         column = columns[i]
         _line[i] = if (typeof line[column] is 'undefined' or line[column] is null) then '' else line[column]
     else
-      for column of line
+      for own column of line
         _line.push line[column]
     line = _line
     _line = null


### PR DESCRIPTION
the usual hasOwnProperty dance was left off and it ended up dying on a node-mysql resultset.
