### PR TITLE
Stringifier.write doesn't handle Number objects.

### DIFF
--- a/src/stringifier.coffee
+++ b/src/stringifier.coffee
@@ -81,6 +81,9 @@ Stringifier.prototype.stringify = (line) ->
       else if field instanceof Date
         # Cast date to timestamp string
         field = '' + field.getTime()
+      else if field instanceof Number
+        # Cast number to string
+        field = '' + field.valueOf()
       if field
         containsdelimiter = field.indexOf(delimiter) >= 0
         containsQuote = field.indexOf(quote) >= 0


### PR DESCRIPTION
While writing a transform that would attempt to turn string versions of booleans and numbers to their real JavaScript types, I ran into a situation where if my transform updated a row value to be a `Number`, I'd get this:

```
events.js:72
        throw er; // Unhandled 'error' event
              ^
TypeError: Object 357 has no method 'indexOf'
    at Stringifier.stringify (/home/me/csv2json/node_modules/csv/lib/stringifier.js:106:35)
    at Stringifier.write (/home/me/csv2json/node_modules/csv/lib/stringifier.js:41:33)
    at finish (/home/me/csv2json/node_modules/csv/lib/transformer.js:171:21)
    at done (/home/me/csv2json/node_modules/csv/lib/transformer.js:202:12)
    at run (/home/me/csv2json/node_modules/csv/lib/transformer.js:209:16)
    at Transformer.write (/home/me/csv2json/node_modules/csv/lib/transformer.js:222:3)
    at null.<anonymous> (/home/me/csv2json/node_modules/csv/lib/index.js:192:29)
    at EventEmitter.emit (events.js:95:17)
    at Parser.write (/home/me/csv2json/node_modules/csv/lib/parser.js:140:14)
    at CSV.write (/home/me/csv2json/node_modules/csv/lib/index.js:275:17)
```

I realize that I can just update my code to use `myNum.valueOf()` but upon looking at the code, it seems you're already trying to do some casting and such so maybe I wasn't doing anything wrong.  Anyway, attached is a patch that handles the `Number` object just like the `Date` object.  I tried updating the existing number support on line 75 to handle this but since it's a `Number` object and not a number literal, it seems this patch is legit.
