### PR TITLE
fix BOM header 0xFEFF problem for ucs2 encoding file

### DIFF
--- a/lib/parser.js
+++ b/lib/parser.js
@@ -55,7 +55,7 @@ Parser.prototype.write = function(chars, end) {
   l = chars.length;
   delimLength = this.options.rowDelimiter ? this.options.rowDelimiter.length : 0;
   i = 0;
-  if (this.lines === 0 && this.options.encoding === 'utf8' && 0xFEFF === chars.charCodeAt(0)) {
+  if (this.lines === 0 && 0xFEFF === chars.charCodeAt(0)) {
     i++;
   }
   while (i < l) {


### PR DESCRIPTION
···if (this.lines === 0 && this.options.encoding === 'utf8' && 0xFEFF === chars.charCodeAt(0)) ···
changed to
···if (this.lines === 0 && 0xFEFF === chars.charCodeAt(0)) ···

The reason is that not only 'utf8' has BOM headers, but also some other encodings, such as 'ucs2'.
so I suggest remove the BOMM header directly.
