### PR TITLE
allow stringifier to handle mongo _ids etc and other objects

### DIFF
--- a/lib/stringifier.js
+++ b/lib/stringifier.js
@@ -101,8 +101,14 @@ Stringifier.prototype.stringify = function(line) {
         field = field ? '1' : '';
       } else if (field instanceof Date) {
         field = '' + field.getTime();
-      } else if (field instanceof Number) {
-        field = '' + field.valueOf();
+      } else {
+        try {
+          field = field.toString();
+        }
+        catch(err) {
+          field = null;
+          console.log("don't know how to stringify a field of type", typeof field);
+        }
       }
       if (field) {
         containsdelimiter = field.indexOf(delimiter) >= 0;


### PR DESCRIPTION
```
csv = require("csv")
fs = require("fs")
async = require("async")
mongo = require("mongodb")
MongoClient = require('mongodb').MongoClient
lu = require("./postcode_areas")


MongoClient.connect("mongodb://127.0.0.1:27017/dummy", (err, db) ->
  if(err) 
    throw err;

  instream = fs.createReadStream(__dirname + "/cqc_locations_export.csv")

  collectionName = "locations"
  collection = db.collection(collectionName)
  db.createIndex(collectionName, {city: 1, region: 1}, (err, db) ->
    queue = async.queue(collection.insert.bind(collection), 5)

    csv().from.stream(instream
    ).transform((row, index, cb) ->
      data =
        name: row[0]
        address: row[2] 
        postcode: row[3] 
        phone: row[4] 
        website: row[5] 

      queue.push data, (err, res) ->
        return err if err
        cb null, res[0]

    ).on("end", (count) ->
      console.log "Number of lines: " + count
    ).on "error", (error) ->
      console.log error.message
    )                                                                           
  )
```
