### PR TITLE
Add preserveObjects option

### DIFF
--- a/lib/from.js
+++ b/lib/from.js
@@ -99,30 +99,6 @@ module.exports = function(csv) {
     }
     return csv;
   };
-
-  /*
-  
-  `from.options([options])`
-  -------------------------
-  
-  Update and retrieve options relative to the input source. Return 
-  the options as an object if no argument is provided.
-  
-  *   `delimiter`     Set the field delimiter. One character only, defaults to comma.
-  *   `rowDelimiter`  String used to delimit record rows or a special value; special values are 'auto', 'unix', 'mac', 'windows', 'unicode'; defaults to 'auto' (discovered in source or 'unix' if no source is specified).
-  *   `quote`         Optionnal character surrounding a field, one character only, defaults to double quotes.
-  *   `escape`        Set the escape character, one character only, defaults to double quotes.
-  *   `columns`       List of fields or true if autodiscovered in the first CSV line, default to null. Impact the `transform` argument and the `data` event by providing an object instead of an array, order matters, see the transform and the columns sections for more details.
-  *   `comment`       Treat all the characteres after this one as a comment, default to '#'
-  *   `flags`         Used to read a file stream, default to the r charactere.
-  *   `encoding`      Encoding of the read stream, defaults to 'utf8', applied when a readable stream is created.
-  *   `trim`          If true, ignore whitespace immediately around the delimiter, defaults to false.
-  *   `ltrim`         If true, ignore whitespace immediately following the delimiter (i.e. left-trim all fields), defaults to false.
-  *   `rtrim`         If true, ignore whitespace immediately preceding the delimiter (i.e. right-trim all fields), defaults to false.
-  
-  Additionnally, in case you are working with stream, you can pass all 
-  the options accepted by the `stream.pipe` function.
-   */
   from.options = function(options) {
     if (options != null) {
       utils.merge(csv.options.from, options);

--- a/lib/options.js
+++ b/lib/options.js
@@ -37,7 +37,8 @@ module.exports = function() {
       encoding: 'utf8',
       newColumns: false,
       end: true,
-      eof: false
+      eof: false,
+      preserveObjects: false
     }
   };
 };

--- a/lib/stringifier.js
+++ b/lib/stringifier.js
@@ -30,7 +30,7 @@ Stringifier.prototype.write = function(line) {
   if (line == null) {
     return;
   }
-  preserve = typeof line !== 'object';
+  preserve = this.csv.options.to.preserveObjects || typeof line !== 'object';
   if (!preserve) {
     try {
       this.csv.emit('record', line, this.csv.state.count - 1);

--- a/lib/to.js
+++ b/lib/to.js
@@ -79,32 +79,6 @@ module.exports = function(csv) {
     }
     return csv;
   };
-
-  /*
-  
-  `to.options([options])`
-  -----------------------
-  
-  Update and retrieve options relative to the output. Return the options
-  as an object if no argument is provided.
-  
-  *   `delimiter`   Set the field delimiter, one character only, defaults to `options.from.delimiter` which is a comma.
-  *   `quote`       Defaults to the quote read option.
-  *   `quoted`      Boolean, default to false, quote all the fields even if not required.
-  *   `escape`      Defaults to the escape read option.
-  *   `columns`     List of fields, applied when `transform` returns an object, order matters, read the transformer documentation for additionnal information.
-  *   `header`      Display the column names on the first line if the columns option is provided.
-  *                 OR create objects with properties named by header titles (when using to.array)
-  *   `objname`     Name of header-record title to name to.objects by.
-  *   `lineBreaks`  String used to delimit record rows or a special value; special values are 'auto', 'unix', 'mac', 'windows', 'unicode'; defaults to 'auto' (discovered in source or 'unix' if no source is specified).
-  *   `flags`       Defaults to 'w', 'w' to create or overwrite an file, 'a' to append to a file. Applied when using the `toPath` method.
-  *   `newColumns`  If the `columns` option is not specified (which means columns will be taken from the reader options, will automatically append new columns if they are added during `transform()`.
-  *   `end`         Prevent calling `end` on the destination, so that destination is no longer writable.
-  *   `eof`         Add a linebreak on the last line, default to false, expect a charactere or use '\n' if value is set to "true"
-  
-  The end options is similar to passing `{end: false}` option in `stream.pipe()`. According to the Node.js documentation:
-  > By default end() is called on the destination when the source stream emits end, so that destination is no longer writable. Pass { end: false } as options to keep the destination stream open.
-   */
   to.options = function(options) {
     if (options != null) {
       utils.merge(csv.options.to, options);

--- a/src/options.coffee
+++ b/src/options.coffee
@@ -38,4 +38,5 @@ module.exports = ->
     newColumns: false
     end: true
     eof: false
+    preserveObjects: false
 

--- a/src/stringifier.coffee
+++ b/src/stringifier.coffee
@@ -22,7 +22,7 @@ The `preserve` argument is for the lines which are not considered as CSV data.
 ###
 Stringifier.prototype.write = (line) ->
   return unless line?
-  preserve = typeof line isnt 'object'
+  preserve = @csv.options.to.preserveObjects or typeof line isnt 'object'
   # Emit and stringify the record
   unless preserve
     # Emit


### PR DESCRIPTION
I needed node-csv to parse an incoming CSV stream, transform each row and then pipe it onwards as objects. I'm not sure of the best way to do this, but simply adding an option to preserve objects instead of stringifying them worked for me. Is there a better way? Of use to anyone else? If so I can write a test case.

For example, given incoming data like:

```
first_name,last_name
John,Doe
Fred,Bloggs
```

and a desired output of:

```
[
   {
      "first_name":"John",
      "last_name":"Doe"
   },
   {
      "first_name":"Fred",
      "last_name":"Bloggs"
   }
]
```

this would work:

``` js
var csv = require('csv');
var fs = require('fs');
var JSONStream = require('JSONStream');

var inFile = fs.createReadStream('./sample.in');
var outFile = fs.createWriteStream('./sample.out');

var csvToObjects = csv()
.from.options({columns:true})
.to.options({preserveObjects:true});

inFile.pipe(csvToObjects).pipe(JSONStream.stringify()).pipe(outFile);
```

In this case I'm just stringifying the stream, but you can imagine having a stream of objects can be useful for writing to a database, etc.
