### PR TITLE
chore: Add files property to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,6 +51,9 @@
     "should": "~13.2.3"
   },
   "optionalDependencies": {},
+  "files": [
+    "lib"
+  ],
   "scripts": {
     "preversion": "grep '## Trunk' CHANGELOG.md",
     "version": "version=`grep '^  \"version\": ' package.json | sed 's/.*\"\\([0-9\\.]*\\)\".*/\\1/'` && sed -i \"s/## Trunk/## Version $version/\" CHANGELOG.md && git add CHANGELOG.md",


### PR DESCRIPTION
This PR will
* add a `files` entry to package.json to avoid publishing unrelated files (e.g. `.travis.yml`)