### PR TITLE
split the exports to support native ES Modules, tree shaking and named imports in ES Modules

### DIFF
--- a/lib/index.mjs
+++ b/lib/index.mjs
@@ -1,0 +1,6 @@
+// Alias to the ES6 modules exposing the stream and callback APIs
+
+export const generate = require('csv-generate/lib')
+export const parse = require('csv-parse/lib')
+export const transform = require('stream-transform/lib')
+export const stringify = require('csv-stringify/lib')

--- a/lib/sync.mjs
+++ b/lib/sync.mjs
@@ -1,0 +1,6 @@
+// Alias to the sync modules exposing the sync API
+
+export const generate = require('csv-generate/lib/sync')
+export const parse = require('csv-parse/lib/sync')
+export const transform = require('stream-transform/lib/sync')
+export const stringify = require('csv-stringify/lib/sync')

--- a/package.json
+++ b/package.json
@@ -88,5 +88,9 @@
     "major": "npm version major -m 'Bump to version %s'",
     "test": "mocha test/**/*.{coffee,ts}"
   },
+  "exports": {
+    "import": "./lib/index.mjs",
+    "require": "./lib/index.js"
+  },
   "types": "./lib/index.d.ts"
 }

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   ],
   "license": "MIT",
   "engines": {
-    "node": ">= 0.1.90"
+    "node": ">= 12.16.0"
   },
   "main": "./lib",
   "repository": {
@@ -89,8 +89,14 @@
     "test": "mocha test/**/*.{coffee,ts}"
   },
   "exports": {
-    "import": "./lib/index.mjs",
-    "require": "./lib/index.js"
+    ".": {
+      "import": "./lib/index.mjs",
+      "require": "./lib/index.js"
+    },
+    "./sync": {
+      "import": "./lib/sync.mjs",
+      "require": "./lib/sync.js"
+    }
   },
   "types": "./lib/index.d.ts"
 }


### PR DESCRIPTION
This is a major semver change.  

Migration
- `require('csv/lib/sync')` to `require('csv/sync')`
- `require('csv/lib')` to `require('csv')`

No changes required in the following situations
- `require('csv')`
- `import csv from 'csv'`
- `import csv from 'csv'; const { parse } = csv`

New options, with `"type": "module"` packages and from mjs scripts:
- `import { parse } from 'csv'`
- `import parse from 'csv/sync'`