### PR TITLE
Usage not good

### DIFF
--- a/packages/csv-stringify/README.md
+++ b/packages/csv-stringify/README.md
@@ -33,12 +33,17 @@ simple callback API is also provided. To give you a quick look, here's an
 example of the callback API:
 
 ```javascript
-var stringify = require('csv-stringify');
+const stringify = require('csv-stringify')
+const assert = require('assert')
+// import stringify from 'csv-stringify'
+// import assert from 'assert/strict'
 
-input = [ [ '1', '2', '3', '4' ], [ 'a', 'b', 'c', 'd' ] ];
-stringify(input, function(err, output){
-  output.should.eql('1,2,3,4\na,b,c,d\n');
-});
+const input = [ [ '1', '2', '3', '4' ], [ 'a', 'b', 'c', 'd' ] ]
+stringify(input, function(err, output) {
+  const expected = '1,2,3,4\na,b,c,d\n'
+  assert.strictEqual(output, expected, `output.should.eql ${expected}`)
+  console.log("Passed.", output)
+})
 ```
 
 ## Development


### PR DESCRIPTION
Made usage good.

Works with all supported Node LTS versions (12 as of now).

The commented out ES Module code only works on Node 15+, but stability of ES Modules didn't reach 2 until Node 16... and the new export removes undesirable deepEquals behavior

# Sandbox Demonstration

[Runkit Sandbox Node 12, 14, 15, 16](https://runkit.com/hesygolu/csv-pr-2021-07-08)