### PR TITLE
Add TypeScript stream.TransformOptions properties to Options

### DIFF
--- a/packages/csv-stringify/lib/index.d.ts
+++ b/packages/csv-stringify/lib/index.d.ts
@@ -17,7 +17,7 @@ export interface CastingContext {
     readonly index: number;
     readonly records: number;
 }
-export interface Options {
+interface Options extends stream.TransformOptions {
     /**
      * Prepend the byte order mark (BOM) to the output stream.
      */

--- a/packages/csv-stringify/lib/index.d.ts
+++ b/packages/csv-stringify/lib/index.d.ts
@@ -17,7 +17,7 @@ export interface CastingContext {
     readonly index: number;
     readonly records: number;
 }
-interface Options extends stream.TransformOptions {
+export interface Options extends stream.TransformOptions {
     /**
      * Prepend the byte order mark (BOM) to the output stream.
      */


### PR DESCRIPTION
To match doc and code:
`super({...{writableObjectMode: true}, ...opts});`
All the options from the Node.js Writable Stream API and the Node.js Readable Stream API are supported and passed as is.