### PR TITLE
fix esm exports in package.json files

### DIFF
--- a/packages/csv-generate/package.json
+++ b/packages/csv-generate/package.json
@@ -36,7 +36,7 @@
       "import": "./lib/sync.js",
       "require": "./dist/cjs/sync.cjs"
     },
-    "./browser/esm/": "./dist/esm/"
+    "./browser/esm/*": "./dist/esm/*.js"
   },
   "files": [
     "dist",

--- a/packages/csv-parse/package.json
+++ b/packages/csv-parse/package.json
@@ -38,7 +38,7 @@
       "import": "./lib/sync.js",
       "require": "./dist/cjs/sync.cjs"
     },
-    "./browser/esm/": "./dist/esm/"
+    "./browser/esm/*": "./dist/esm/*.js"
   },
   "devDependencies": {
     "@rollup/plugin-eslint": "^8.0.1",

--- a/packages/csv-stringify/package.json
+++ b/packages/csv-stringify/package.json
@@ -36,7 +36,7 @@
       "import": "./lib/sync.js",
       "require": "./dist/cjs/sync.cjs"
     },
-    "./browser/esm/": "./dist/esm/"
+    "./browser/esm/*": "./dist/esm/*.js"
   },
   "files": [
     "dist",

--- a/packages/csv/package.json
+++ b/packages/csv/package.json
@@ -54,7 +54,7 @@
       "import": "./lib/sync.js",
       "require": "./dist/cjs/sync.cjs"
     },
-    "./browser/esm/": "./dist/esm/"
+    "./browser/esm/*": "./dist/esm/*.js"
   },
   "homepage": "https://csv.js.org/",
   "files": [

--- a/packages/stream-transform/package.json
+++ b/packages/stream-transform/package.json
@@ -36,7 +36,7 @@
       "import": "./lib/sync.js",
       "require": "./dist/cjs/sync.cjs"
     },
-    "./browser/esm/": "./dist/esm/"
+    "./browser/esm/*": "./dist/esm/*.js"
   },
   "files": [
     "dist",


### PR DESCRIPTION
Nodejs does not allow to export directories, but it is possible to use subpath patterns to achieve this. 

See https://nodejs.org/api/packages.html#subpath-patterns

**Reproduce**

```
// test.mjs
import { stringify } from 'csv-stringify/browser/esm/index.js';
```

```
$ node test.mjs
node:internal/errors:464
    ErrorCaptureStackTrace(err);
    ^

Error [ERR_PACKAGE_PATH_NOT_EXPORTED]: Package subpath './browser/esm/index.js' is not defined by "exports" in /home/xxx/test/node_modules/csv-stringify/package.json imported from /home/xxx/test/test.mjs
    at new NodeError (node:internal/errors:371:5)
    at throwExportsNotFound (node:internal/modules/esm/resolve:429:9)
    at packageExportsResolve (node:internal/modules/esm/resolve:683:3)
    at packageResolve (node:internal/modules/esm/resolve:853:14)
    at moduleResolve (node:internal/modules/esm/resolve:910:18)
    at defaultResolve (node:internal/modules/esm/resolve:1005:11)
    at ESMLoader.resolve (node:internal/modules/esm/loader:475:30)
    at ESMLoader.getModuleJob (node:internal/modules/esm/loader:245:18)
    at ModuleWrap.<anonymous> (node:internal/modules/esm/module_job:79:40)
    at link (node:internal/modules/esm/module_job:78:36) {
  code: 'ERR_PACKAGE_PATH_NOT_EXPORTED'
}

Node.js v17.1.0
```

With Node 16 you get a deprecation warning

```
(node:102) [DEP0148] DeprecationWarning: Use of deprecated folder mapping "./browser/esm/" in the "exports" field module resolution of the package at /home/xxx/test/node_modules/csv-stringify/package.json.
Update this package.json to use a subpath pattern like "./browser/esm/*".
```