### PR TITLE
fix(csv-stringify): update TS types to allow cast to return an object

### DIFF
--- a/packages/csv-stringify/lib/index.d.ts
+++ b/packages/csv-stringify/lib/index.d.ts
@@ -4,7 +4,24 @@ import * as stream from "stream";
 
 export type Callback = (err: Error | undefined, output: string) => void
 export type RecordDelimiter = string | Buffer | 'auto' | 'unix' | 'mac' | 'windows' | 'ascii' | 'unicode'
-export type Cast<T> = (value: T, context: CastingContext) => string
+
+export type CastReturnObject = { value: string } & Pick<
+    Options,
+    | 'delimiter'
+    | 'escape'
+    | 'quote'
+    | 'quoted'
+    | 'quoted_empty'
+    | 'quoted_string'
+    | 'quoted_match'
+    | 'record_delimiter'
+>
+
+export type Cast<T> = (
+    value: T,
+    context: CastingContext
+) => string | CastReturnObject;
+
 export type PlainObject<T> = Record<string, T>
 export type Input = any[]
 export interface ColumnOption {

--- a/packages/csv-stringify/test/api.types.sync.ts
+++ b/packages/csv-stringify/test/api.types.sync.ts
@@ -37,5 +37,17 @@ describe('API Types', () => {
     }
     return options
   })
+
+  it('allows cast to return an object', () => {
+    const options: Options = {
+      cast: {
+        boolean: (value: boolean) => ({
+          value: value.toString(),
+          delimiter: ';',
+          quote: false
+        })
+      }
+    }
+  })
   
 })


### PR DESCRIPTION
Closes #337.

When I built the codebase, it updated all of the compiled code which is tracked by git. I'm not sure if I was supposed to commit these changes.

My actual code changes are to:
- `packages/csv-stringify/lib/index.d.ts`
- `packages/csv-stringify/test/api.types.sync.ts`