### PR TITLE
fix: add type declaration paths to exports field

### DIFF
--- a/demo/ts-module-node16/lib/stringify.ts
+++ b/demo/ts-module-node16/lib/stringify.ts
@@ -1,0 +1,32 @@
+
+import assert from 'assert'
+import { stringify, Stringifier } from 'csv-stringify';
+
+let output: string = '';
+// Create the parser
+const stringifier: Stringifier = stringify({
+  delimiter: ':',
+  encoding: 'utf8'
+});
+// Use the readable stream api to consume records
+stringifier.on('readable', function(){
+  let record; while ((record = stringifier.read()) !== null) {
+    output += record
+  }
+});
+// Catch any error
+stringifier.on('error', function(err){
+  console.error(err.message)
+});
+// Test that the parsed records matched what's expected
+stringifier.on('end', function(){
+  assert.deepStrictEqual(
+    output,
+    'a:b:c\n1:2:3\n'
+  )
+});
+// Write data to the stream
+stringifier.write(["a", "b", "c"]);
+stringifier.write([1, 2, 3]);
+// Close the readable stream
+stringifier.end();

--- a/demo/ts-module-node16/package.json
+++ b/demo/ts-module-node16/package.json
@@ -1,0 +1,31 @@
+{
+  "name": "csv-ts-demo-node16",
+  "version": "0.0.0",
+  "main": "index.js",
+  "license": "MIT",
+  "type": "module",
+  "private": true,
+  "devDependencies": {
+    "@types/node": "^18.0.3",
+    "coffeescript": "^2.7.0",
+    "mocha": "^10.0.0",
+    "should": "^13.2.3",
+    "ts-node": "^10.8.2",
+    "typescript": "^4.7.4"
+  },
+  "mocha": {
+    "inline-diffs": true,
+    "loader": "./test/loaders/all.js",
+    "recursive": true,
+    "reporter": "spec",
+    "require": [
+      "should"
+    ],
+    "throw-deprecation": true,
+    "timeout": 40000
+  },
+  "scripts": {
+    "test": "mocha 'test/**/*.coffee'",
+    "test:legacy": "mocha --loader=./test/loaders/legacy/all.js 'test/**/*.{coffee,ts}'"
+  }
+}

--- a/demo/ts-module-node16/test/loaders/all.js
+++ b/demo/ts-module-node16/test/loaders/all.js
@@ -1,0 +1,16 @@
+
+import * as coffee from './coffee.js'
+import * as ts from 'ts-node/esm'
+
+const coffeeRegex = /\.coffee$|\.litcoffee$|\.coffee\.md$/;
+const tsRegex = /\.ts$/;
+
+export function load(url, context, next) {
+  if (coffeeRegex.test(url)) {
+    return coffee.load.apply(this, arguments)
+  }
+  if (tsRegex.test(url)) {
+    return ts.load.apply(this, arguments)
+  }
+  return next(url, context, next);
+}

--- a/demo/ts-module-node16/test/loaders/coffee.js
+++ b/demo/ts-module-node16/test/loaders/coffee.js
@@ -1,0 +1,20 @@
+import CoffeeScript from 'coffeescript';
+
+// See https://github.com/nodejs/node/issues/36396
+const extensionsRegex = /\.coffee$|\.litcoffee$|\.coffee\.md$/;
+
+export async function load(url, context, next) {
+  if (extensionsRegex.test(url)) {
+    const format = 'module';
+    const { source: rawSource } = await next(url, { format });
+    const source = CoffeeScript.compile(rawSource.toString(), {
+      bare: true,
+      inlineMap: true,
+      filename: url,
+      header: false,
+      sourceMap: false,
+    });
+    return {format, source};
+  }
+  return next(url, context);
+}

--- a/demo/ts-module-node16/test/loaders/legacy/all.js
+++ b/demo/ts-module-node16/test/loaders/legacy/all.js
@@ -1,0 +1,37 @@
+
+import * as coffee from './coffee.js'
+import * as ts from 'ts-node/esm'
+
+const coffeeRegex = /\.coffee$|\.litcoffee$|\.coffee\.md$/;
+const tsRegex = /\.ts$/;
+
+export function resolve(specifier, context, defaultResolve) {
+  if (coffeeRegex.test(specifier)) {
+    return coffee.resolve.apply(this, arguments)
+  }
+  if (tsRegex.test(specifier)) {
+    return ts.resolve.apply(this, arguments)
+  }
+  return ts.resolve.apply(this, arguments);
+}
+
+export function getFormat(url, context, defaultGetFormat) {
+  if (coffeeRegex.test(url)) {
+    return coffee.getFormat.apply(this, arguments)
+  }
+  if (tsRegex.test(url)) {
+    return ts.getFormat.apply(this, arguments)
+  }
+  return ts.getFormat.apply(this, arguments);
+}
+
+export function transformSource(source, context, defaultTransformSource) {
+  const { url } = context;
+  if (coffeeRegex.test(url)) {
+    return coffee.transformSource.apply(this, arguments)
+  }
+  if (tsRegex.test(url)) {
+    return ts.transformSource.apply(this, arguments)
+  }
+  return ts.transformSource.apply(this, arguments);
+}

--- a/demo/ts-module-node16/test/loaders/legacy/coffee.js
+++ b/demo/ts-module-node16/test/loaders/legacy/coffee.js
@@ -1,0 +1,50 @@
+// coffeescript-loader.mjs
+import { URL, pathToFileURL } from 'url';
+import CoffeeScript from 'coffeescript';
+import { cwd } from 'process';
+
+const baseURL = pathToFileURL(`${cwd()}/`).href;
+
+// CoffeeScript files end in .coffee, .litcoffee or .coffee.md.
+const extensionsRegex = /\.coffee$|\.litcoffee$|\.coffee\.md$/;
+
+export function resolve(specifier, context, defaultResolve) {
+  const { parentURL = baseURL } = context;
+  // Node.js normally errors on unknown file extensions, so return a URL for
+  // specifiers ending in the CoffeeScript file extensions.
+  if (extensionsRegex.test(specifier)) {
+    return {
+      url: new URL(specifier, parentURL).href,
+      stop: true
+    };
+  }
+  // Let Node.js handle all other specifiers.
+  return defaultResolve(specifier, context, defaultResolve);
+}
+
+export function getFormat(url, context, defaultGetFormat) {
+  // Now that we patched resolve to let CoffeeScript URLs through, we need to
+  // tell Node.js what format such URLs should be interpreted as. For the
+  // purposes of this loader, all CoffeeScript URLs are ES modules.
+  if (extensionsRegex.test(url)) {
+    return {
+      format: 'module',
+      stop: true
+    };
+  }
+  // Let Node.js handle all other URLs.
+  return defaultGetFormat(url, context, defaultGetFormat);
+}
+
+export function transformSource(source, context, defaultTransformSource) {
+  const { url, format } = context;
+
+  if (extensionsRegex.test(url)) {
+    return {
+      source: CoffeeScript.compile(String(source), { bare: true })
+    };
+  }
+
+  // Let Node.js handle all other sources.
+  return defaultTransformSource(source, context, defaultTransformSource);
+}

--- a/demo/ts-module-node16/test/samples.coffee
+++ b/demo/ts-module-node16/test/samples.coffee
@@ -1,0 +1,26 @@
+
+import fs from 'fs'
+import path from 'path'
+import { exec } from 'child_process'
+
+import { fileURLToPath } from 'url'
+__dirname = path.dirname fileURLToPath import.meta.url
+dir = path.resolve __dirname, '../lib'
+samples = fs.readdirSync dir
+
+describe 'Samples', ->
+
+  samples
+  .filter (sample) ->
+    return false unless /\.(js|ts)?$/.test sample
+    true
+  .map (sample) ->
+    it "Sample #{sample}", (callback) ->
+      ext = /\.(\w+)?$/.exec(sample)[0]
+      bin = switch ext
+        when '.js'
+          'node'
+        when '.ts'
+          'node --loader ts-node/esm'
+      exec "#{bin} #{path.resolve dir, sample}", (err, stdout, stderr) ->
+        callback err

--- a/demo/ts-module-node16/tsconfig.json
+++ b/demo/ts-module-node16/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "compilerOptions": {
+    "esModuleInterop": true,
+    "module": "Node16",
+    "strict": true,
+  }
+}

--- a/packages/csv-generate/dist/cjs/stream.d.ts
+++ b/packages/csv-generate/dist/cjs/stream.d.ts
@@ -1,0 +1,6 @@
+
+import { Options } from './index';
+
+declare function generate(options?: Options): ReadableStream<Buffer>;
+// export default generate;
+export { generate, Options };

--- a/packages/csv-generate/dist/esm/stream.d.ts
+++ b/packages/csv-generate/dist/esm/stream.d.ts
@@ -1,0 +1,6 @@
+
+import { Options } from './index';
+
+declare function generate(options?: Options): ReadableStream<Buffer>;
+// export default generate;
+export { generate, Options };

--- a/packages/csv-generate/lib/stream.d.ts
+++ b/packages/csv-generate/lib/stream.d.ts
@@ -1,0 +1,6 @@
+
+import { Options } from './index';
+
+declare function generate(options?: Options): ReadableStream<Buffer>;
+// export default generate;
+export { generate, Options };

--- a/packages/csv-generate/package.json
+++ b/packages/csv-generate/package.json
@@ -38,6 +38,11 @@
       "require": "./dist/cjs/sync.cjs",
       "types": "./lib/sync.d.ts"
     },
+    "./stream": {
+      "import": "./lib/stream.js",
+      "require": "./dist/cjs/stream.cjs",
+      "types": "./lib/stream.d.ts"
+    },
     "./browser/esm": {
       "types": "./lib/index.d.ts",
       "default": "./dist/esm/index.js"

--- a/packages/csv-generate/package.json
+++ b/packages/csv-generate/package.json
@@ -30,18 +30,22 @@
   "exports": {
     ".": {
       "import": "./lib/index.js",
-      "require": "./dist/cjs/index.cjs"
+      "require": "./dist/cjs/index.cjs",
+      "types": "./lib/index.d.ts"
     },
     "./sync": {
       "import": "./lib/sync.js",
-      "require": "./dist/cjs/sync.cjs"
+      "require": "./dist/cjs/sync.cjs",
+      "types": "./lib/sync.d.ts"
     },
-    "./stream": {
-      "import": "./lib/stream.js",
-      "require": "./dist/cjs/stream.cjs"
+    "./browser/esm": {
+      "types": "./lib/index.d.ts",
+      "default": "./dist/esm/index.js"
     },
-    "./browser/esm": "./dist/esm/index.js",
-    "./browser/esm/sync": "./dist/esm/sync.js"
+    "./browser/esm/sync": {
+      "types": "./lib/sync.d.ts",
+      "default": "./dist/esm/sync.js"
+    }
   },
   "files": [
     "dist",

--- a/packages/csv-parse/package.json
+++ b/packages/csv-parse/package.json
@@ -32,14 +32,22 @@
   "exports": {
     ".": {
       "import": "./lib/index.js",
-      "require": "./dist/cjs/index.cjs"
+      "require": "./dist/cjs/index.cjs",
+      "types": "./lib/index.d.ts"
     },
     "./sync": {
       "import": "./lib/sync.js",
-      "require": "./dist/cjs/sync.cjs"
+      "require": "./dist/cjs/sync.cjs",
+      "types": "./lib/sync.d.ts"
     },
-    "./browser/esm": "./dist/esm/index.js",
-    "./browser/esm/sync": "./dist/esm/sync.js"
+    "./browser/esm": {
+      "types": "./lib/index.d.ts",
+      "default": "./dist/esm/index.js"
+    },
+    "./browser/esm/sync": {
+      "types": "./lib/sync.d.ts",
+      "default": "./dist/esm/sync.js"
+    }
   },
   "devDependencies": {
     "@rollup/plugin-eslint": "^8.0.2",

--- a/packages/csv-stringify/package.json
+++ b/packages/csv-stringify/package.json
@@ -30,14 +30,22 @@
   "exports": {
     ".": {
       "import": "./lib/index.js",
-      "require": "./dist/cjs/index.cjs"
+      "require": "./dist/cjs/index.cjs",
+      "types": "./lib/index.d.ts"
     },
     "./sync": {
       "import": "./lib/sync.js",
-      "require": "./dist/cjs/sync.cjs"
+      "require": "./dist/cjs/sync.cjs",
+      "types": "./lib/sync.d.ts"
     },
-    "./browser/esm": "./dist/esm/index.js",
-    "./browser/esm/sync": "./dist/esm/sync.js"
+    "./browser/esm": {
+      "types": "./lib/index.d.ts",
+      "default": "./dist/esm/index.js"
+    },
+    "./browser/esm/sync": {
+      "types": "./lib/sync.d.ts",
+      "default": "./dist/esm/sync.js"
+    }
   },
   "files": [
     "dist",

--- a/packages/csv/package.json
+++ b/packages/csv/package.json
@@ -48,14 +48,22 @@
   "exports": {
     ".": {
       "import": "./lib/index.js",
-      "require": "./dist/cjs/index.cjs"
+      "require": "./dist/cjs/index.cjs",
+      "types": "./lib/index.d.ts"
     },
     "./sync": {
       "import": "./lib/sync.js",
-      "require": "./dist/cjs/sync.cjs"
+      "require": "./dist/cjs/sync.cjs",
+      "types": "./lib/sync.d.ts"
     },
-    "./browser/esm": "./dist/esm/index.js",
-    "./browser/esm/sync": "./dist/esm/sync.js"
+    "./browser/esm": {
+      "types": "./lib/index.d.ts",
+      "default": "./dist/esm/index.js"
+    },
+    "./browser/esm/sync": {
+      "types": "./lib/sync.d.ts",
+      "default": "./dist/esm/sync.js"
+    }
   },
   "homepage": "https://csv.js.org/",
   "files": [

--- a/packages/stream-transform/package.json
+++ b/packages/stream-transform/package.json
@@ -30,14 +30,22 @@
   "exports": {
     ".": {
       "import": "./lib/index.js",
-      "require": "./dist/cjs/index.cjs"
+      "require": "./dist/cjs/index.cjs",
+      "types": "./lib/index.d.ts"
     },
     "./sync": {
       "import": "./lib/sync.js",
-      "require": "./dist/cjs/sync.cjs"
+      "require": "./dist/cjs/sync.cjs",
+      "types": "./lib/sync.d.ts"
     },
-    "./browser/esm": "./dist/esm/index.js",
-    "./browser/esm/sync": "./dist/esm/sync.js"
+    "./browser/esm": {
+      "types": "./lib/index.d.ts",
+      "default": "./dist/esm/index.js"
+    },
+    "./browser/esm/sync": {
+      "types": "./lib/sync.d.ts",
+      "default": "./dist/esm/sync.js"
+    }
   },
   "files": [
     "dist",


### PR DESCRIPTION
With TypeScript 4.7, a new `module` was introduced: `Node16`. https://devblogs.microsoft.com/typescript/announcing-typescript-4-7/#esm-nodejs

When using strict mode with module Node16, you receive the following error message because the type declaration cannot be found:

```
Could not find a declaration file for module 'csv-stringify'. '.../node_modules/csv-stringify/dist/cjs/index.cjs' implicitly has an 'any' type.
  Try `npm i --save-dev @types/csv-stringify` if it exists or add a new declaration (.d.ts) file containing `declare module 'csv-stringify';`
```

## Reproduction

Create a new project with the following dependencies
* `typescript`: 4.7.2
* `csv-stringify`: 6.1.0

Create the following files:
```json
// tsconfig.json
{
    "compilerOptions": {
        "module": "Node16",
        "strict": true
    }
}
```
```
// index.ts
import { stringify } from 'csv-stringify';
```

When building the project, you receive the error message above.


## Solution

This issue can be solved by adding the `types` to the `exports` field in package.json 