### PR TITLE
fix(csv-parse): encoding detection with bom

### DIFF
--- a/packages/csv-parse/dist/cjs/index.cjs
+++ b/packages/csv-parse/dist/cjs/index.cjs
@@ -635,8 +635,8 @@ const transform = function(original_options = {}) {
     },
     // Central parser implementation
     parse: function(nextBuf, end, push, close){
-      const {bom, comment, escape, from_line, ltrim, max_record_size, quote, raw, relax_quotes, rtrim, skip_empty_lines, to, to_line} = this.options;
-      let {record_delimiter} = this.options;
+      const {bom, from_line, ltrim, max_record_size,raw, relax_quotes, rtrim, skip_empty_lines, to, to_line} = this.options;
+      let {comment, escape, quote, record_delimiter, } = this.options;
       const {bomSkipped, previousBuf, rawBuffer, escapeIsQuote} = this.state;
       let buf;
       if(previousBuf === undefined){
@@ -672,6 +672,8 @@ const transform = function(original_options = {}) {
               buf = buf.slice(bomLength);
               // Renormalize original options with the new encoding
               this.options = normalize_options({...this.original_options, encoding: encoding});
+              // Options will re-evaluate the Buffer with the new encoding
+              ({comment, escape, quote } = this.options);
               break;
             }
           }

--- a/packages/csv-parse/dist/cjs/sync.cjs
+++ b/packages/csv-parse/dist/cjs/sync.cjs
@@ -633,8 +633,8 @@ const transform = function(original_options = {}) {
     },
     // Central parser implementation
     parse: function(nextBuf, end, push, close){
-      const {bom, comment, escape, from_line, ltrim, max_record_size, quote, raw, relax_quotes, rtrim, skip_empty_lines, to, to_line} = this.options;
-      let {record_delimiter} = this.options;
+      const {bom, from_line, ltrim, max_record_size,raw, relax_quotes, rtrim, skip_empty_lines, to, to_line} = this.options;
+      let {comment, escape, quote, record_delimiter, } = this.options;
       const {bomSkipped, previousBuf, rawBuffer, escapeIsQuote} = this.state;
       let buf;
       if(previousBuf === undefined){
@@ -670,6 +670,8 @@ const transform = function(original_options = {}) {
               buf = buf.slice(bomLength);
               // Renormalize original options with the new encoding
               this.options = normalize_options({...this.original_options, encoding: encoding});
+              // Options will re-evaluate the Buffer with the new encoding
+              ({comment, escape, quote } = this.options);
               break;
             }
           }

--- a/packages/csv-parse/dist/esm/index.js
+++ b/packages/csv-parse/dist/esm/index.js
@@ -5691,8 +5691,8 @@ const transform = function(original_options = {}) {
     },
     // Central parser implementation
     parse: function(nextBuf, end, push, close){
-      const {bom, comment, escape, from_line, ltrim, max_record_size, quote, raw, relax_quotes, rtrim, skip_empty_lines, to, to_line} = this.options;
-      let {record_delimiter} = this.options;
+      const {bom, from_line, ltrim, max_record_size,raw, relax_quotes, rtrim, skip_empty_lines, to, to_line} = this.options;
+      let {comment, escape, quote, record_delimiter, } = this.options;
       const {bomSkipped, previousBuf, rawBuffer, escapeIsQuote} = this.state;
       let buf;
       if(previousBuf === undefined){
@@ -5728,6 +5728,8 @@ const transform = function(original_options = {}) {
               buf = buf.slice(bomLength);
               // Renormalize original options with the new encoding
               this.options = normalize_options({...this.original_options, encoding: encoding});
+              // Options will re-evaluate the Buffer with the new encoding
+              ({comment, escape, quote } = this.options);
               break;
             }
           }

--- a/packages/csv-parse/dist/esm/sync.js
+++ b/packages/csv-parse/dist/esm/sync.js
@@ -2601,8 +2601,8 @@ const transform = function(original_options = {}) {
     },
     // Central parser implementation
     parse: function(nextBuf, end, push, close){
-      const {bom, comment, escape, from_line, ltrim, max_record_size, quote, raw, relax_quotes, rtrim, skip_empty_lines, to, to_line} = this.options;
-      let {record_delimiter} = this.options;
+      const {bom, from_line, ltrim, max_record_size,raw, relax_quotes, rtrim, skip_empty_lines, to, to_line} = this.options;
+      let {comment, escape, quote, record_delimiter, } = this.options;
       const {bomSkipped, previousBuf, rawBuffer, escapeIsQuote} = this.state;
       let buf;
       if(previousBuf === undefined){
@@ -2638,6 +2638,8 @@ const transform = function(original_options = {}) {
               buf = buf.slice(bomLength);
               // Renormalize original options with the new encoding
               this.options = normalize_options({...this.original_options, encoding: encoding});
+              // Options will re-evaluate the Buffer with the new encoding
+              ({comment, escape, quote } = this.options);
               break;
             }
           }

--- a/packages/csv-parse/dist/iife/index.js
+++ b/packages/csv-parse/dist/iife/index.js
@@ -5694,8 +5694,8 @@ var csv_parse = (function (exports) {
                 },
                 // Central parser implementation
                 parse: function(nextBuf, end, push, close){
-                  const {bom, comment, escape, from_line, ltrim, max_record_size, quote, raw, relax_quotes, rtrim, skip_empty_lines, to, to_line} = this.options;
-                  let {record_delimiter} = this.options;
+                  const {bom, from_line, ltrim, max_record_size,raw, relax_quotes, rtrim, skip_empty_lines, to, to_line} = this.options;
+                  let {comment, escape, quote, record_delimiter, } = this.options;
                   const {bomSkipped, previousBuf, rawBuffer, escapeIsQuote} = this.state;
                   let buf;
                   if(previousBuf === undefined){
@@ -5731,6 +5731,8 @@ var csv_parse = (function (exports) {
                           buf = buf.slice(bomLength);
                           // Renormalize original options with the new encoding
                           this.options = normalize_options({...this.original_options, encoding: encoding});
+                          // Options will re-evaluate the Buffer with the new encoding
+                          ({comment, escape, quote } = this.options);
                           break;
                         }
                       }

--- a/packages/csv-parse/dist/iife/sync.js
+++ b/packages/csv-parse/dist/iife/sync.js
@@ -2604,8 +2604,8 @@ var csv_parse_sync = (function (exports) {
                 },
                 // Central parser implementation
                 parse: function(nextBuf, end, push, close){
-                  const {bom, comment, escape, from_line, ltrim, max_record_size, quote, raw, relax_quotes, rtrim, skip_empty_lines, to, to_line} = this.options;
-                  let {record_delimiter} = this.options;
+                  const {bom, from_line, ltrim, max_record_size,raw, relax_quotes, rtrim, skip_empty_lines, to, to_line} = this.options;
+                  let {comment, escape, quote, record_delimiter, } = this.options;
                   const {bomSkipped, previousBuf, rawBuffer, escapeIsQuote} = this.state;
                   let buf;
                   if(previousBuf === undefined){
@@ -2641,6 +2641,8 @@ var csv_parse_sync = (function (exports) {
                           buf = buf.slice(bomLength);
                           // Renormalize original options with the new encoding
                           this.options = normalize_options({...this.original_options, encoding: encoding});
+                          // Options will re-evaluate the Buffer with the new encoding
+                          ({comment, escape, quote } = this.options);
                           break;
                         }
                       }

--- a/packages/csv-parse/dist/umd/index.js
+++ b/packages/csv-parse/dist/umd/index.js
@@ -5697,8 +5697,8 @@
                 },
                 // Central parser implementation
                 parse: function(nextBuf, end, push, close){
-                  const {bom, comment, escape, from_line, ltrim, max_record_size, quote, raw, relax_quotes, rtrim, skip_empty_lines, to, to_line} = this.options;
-                  let {record_delimiter} = this.options;
+                  const {bom, from_line, ltrim, max_record_size,raw, relax_quotes, rtrim, skip_empty_lines, to, to_line} = this.options;
+                  let {comment, escape, quote, record_delimiter, } = this.options;
                   const {bomSkipped, previousBuf, rawBuffer, escapeIsQuote} = this.state;
                   let buf;
                   if(previousBuf === undefined){
@@ -5734,6 +5734,8 @@
                           buf = buf.slice(bomLength);
                           // Renormalize original options with the new encoding
                           this.options = normalize_options({...this.original_options, encoding: encoding});
+                          // Options will re-evaluate the Buffer with the new encoding
+                          ({comment, escape, quote } = this.options);
                           break;
                         }
                       }

--- a/packages/csv-parse/dist/umd/sync.js
+++ b/packages/csv-parse/dist/umd/sync.js
@@ -2607,8 +2607,8 @@
                 },
                 // Central parser implementation
                 parse: function(nextBuf, end, push, close){
-                  const {bom, comment, escape, from_line, ltrim, max_record_size, quote, raw, relax_quotes, rtrim, skip_empty_lines, to, to_line} = this.options;
-                  let {record_delimiter} = this.options;
+                  const {bom, from_line, ltrim, max_record_size,raw, relax_quotes, rtrim, skip_empty_lines, to, to_line} = this.options;
+                  let {comment, escape, quote, record_delimiter, } = this.options;
                   const {bomSkipped, previousBuf, rawBuffer, escapeIsQuote} = this.state;
                   let buf;
                   if(previousBuf === undefined){
@@ -2644,6 +2644,8 @@
                           buf = buf.slice(bomLength);
                           // Renormalize original options with the new encoding
                           this.options = normalize_options({...this.original_options, encoding: encoding});
+                          // Options will re-evaluate the Buffer with the new encoding
+                          ({comment, escape, quote } = this.options);
                           break;
                         }
                       }

--- a/packages/csv-parse/lib/api/index.js
+++ b/packages/csv-parse/lib/api/index.js
@@ -55,8 +55,8 @@ const transform = function(original_options = {}) {
     },
     // Central parser implementation
     parse: function(nextBuf, end, push, close){
-      const {bom, comment, escape, from_line, ltrim, max_record_size, quote, raw, relax_quotes, rtrim, skip_empty_lines, to, to_line} = this.options;
-      let {record_delimiter} = this.options;
+      const {bom, from_line, ltrim, max_record_size,raw, relax_quotes, rtrim, skip_empty_lines, to, to_line} = this.options;
+      let {comment, escape, quote, record_delimiter, } = this.options;
       const {bomSkipped, previousBuf, rawBuffer, escapeIsQuote} = this.state;
       let buf;
       if(previousBuf === undefined){
@@ -92,6 +92,8 @@ const transform = function(original_options = {}) {
               buf = buf.slice(bomLength);
               // Renormalize original options with the new encoding
               this.options = normalize_options({...this.original_options, encoding: encoding});
+              // Options will re-evaluate the Buffer with the new encoding
+              ({comment, escape, quote } = this.options);
               break;
             }
           }

--- a/packages/csv-parse/test/option.encoding.coffee
+++ b/packages/csv-parse/test/option.encoding.coffee
@@ -78,6 +78,6 @@ describe 'Option `encoding`', ->
         ] unless err
         next err
       # parser.write Buffer.from Buffer.from([255, 254])
-      parser.write Buffer.from "\ufeffa,b,c\n", 'utf16le'
+      parser.write Buffer.from '\ufeffa,b,"c"\n', 'utf16le'
       parser.write Buffer.from 'd,e,f', 'utf16le'
       parser.end()


### PR DESCRIPTION
This fixes https://github.com/adaltas/node-csv-parse/issues/318 

**Describe the bug**

Following test is failing:

```javascript
import csvParse from 'csv-parse/lib/sync';

test('This is not working', () => {
      const data = Buffer.from('\uFEFFa,b,c\n"a","b","c"', 'utf16le');
      const records = csvParse(data, {
        bom: true,
      });
      expect(records).toEqual([
        ['a', 'b', 'c'],
        ['a', 'b', 'c'], // Got ["愀", "戀", "挀"]
      ]);
});
```

After some research, I found that while the options are re-evaluated upon encoding change, we still use old values for comment, escape & quote values.