### PR TITLE
feat(ts): set `columns` type as `readonly`

### DIFF
--- a/packages/csv-stringify/lib/index.d.ts
+++ b/packages/csv-stringify/lib/index.d.ts
@@ -60,7 +60,7 @@ export interface Options extends stream.TransformOptions {
      * can refer to nested properties of the input JSON
      * see the "header" option on how to print columns names on the first line
      */
-    columns?: string[] | PlainObject<string> | ColumnOption[]
+    columns?: readonly string[] | PlainObject<string> | readonly ColumnOption[]
     /**
      * Set the field delimiter, one character only, defaults to a comma.
      */


### PR DESCRIPTION
The goal is for stringify to support values declared `as const`. 

eg.
```
const columns = ['name', 'age'] as const

stringify({columns})
```

As this array has no reasons to be mutated by `stringify` it's simpler to set it as `readonly`.