### PR TITLE
fix: support TypeScript moduleResolution node16

### DIFF
--- a/packages/csv-generate/dist/cjs/stream.d.ts
+++ b/packages/csv-generate/dist/cjs/stream.d.ts
@@ -1,5 +1,5 @@
 
-import { Options } from './index';
+import { Options } from './index.js';
 
 declare function generate(options?: Options): ReadableStream<Buffer>;
 // export default generate;

--- a/packages/csv-generate/dist/cjs/sync.d.ts
+++ b/packages/csv-generate/dist/cjs/sync.d.ts
@@ -1,5 +1,5 @@
 
-import { Options } from './index';
+import { Options } from './index.js';
 
 declare function generate<T = any>(options: number | Options): string & Array<T>;
 // export default generate;

--- a/packages/csv-generate/dist/esm/stream.d.ts
+++ b/packages/csv-generate/dist/esm/stream.d.ts
@@ -1,5 +1,5 @@
 
-import { Options } from './index';
+import { Options } from './index.js';
 
 declare function generate(options?: Options): ReadableStream<Buffer>;
 // export default generate;

--- a/packages/csv-generate/dist/esm/sync.d.ts
+++ b/packages/csv-generate/dist/esm/sync.d.ts
@@ -1,5 +1,5 @@
 
-import { Options } from './index';
+import { Options } from './index.js';
 
 declare function generate<T = any>(options: number | Options): string & Array<T>;
 // export default generate;

--- a/packages/csv-generate/lib/stream.d.ts
+++ b/packages/csv-generate/lib/stream.d.ts
@@ -1,5 +1,5 @@
 
-import { Options } from './index';
+import { Options } from './index.js';
 
 declare function generate(options?: Options): ReadableStream<Buffer>;
 // export default generate;

--- a/packages/csv-generate/lib/sync.d.ts
+++ b/packages/csv-generate/lib/sync.d.ts
@@ -1,5 +1,5 @@
 
-import { Options } from './index';
+import { Options } from './index.js';
 
 declare function generate<T = any>(options: number | Options): string & Array<T>;
 // export default generate;

--- a/packages/csv-parse/dist/cjs/sync.d.ts
+++ b/packages/csv-parse/dist/cjs/sync.d.ts
@@ -1,5 +1,5 @@
 
-import { Options } from './index';
+import { Options } from './index.js';
 
 declare function parse(input: Buffer | string, options?: Options): any;
 // export default parse;
@@ -8,4 +8,4 @@ export { parse };
 export {
   CastingContext, CastingFunction, CastingDateFunction,
   ColumnOption, Options, Info, CsvErrorCode, CsvError
-} from './index';
+} from './index.js';

--- a/packages/csv-parse/dist/esm/sync.d.ts
+++ b/packages/csv-parse/dist/esm/sync.d.ts
@@ -1,5 +1,5 @@
 
-import { Options } from './index';
+import { Options } from './index.js';
 
 declare function parse(input: Buffer | string, options?: Options): any;
 // export default parse;
@@ -8,4 +8,4 @@ export { parse };
 export {
   CastingContext, CastingFunction, CastingDateFunction,
   ColumnOption, Options, Info, CsvErrorCode, CsvError
-} from './index';
+} from './index.js';

--- a/packages/csv-parse/lib/sync.d.ts
+++ b/packages/csv-parse/lib/sync.d.ts
@@ -1,5 +1,5 @@
 
-import { Options } from './index';
+import { Options } from './index.js';
 
 declare function parse(input: Buffer | string, options?: Options): any;
 // export default parse;
@@ -8,4 +8,4 @@ export { parse };
 export {
   CastingContext, CastingFunction, CastingDateFunction,
   ColumnOption, Options, Info, CsvErrorCode, CsvError
-} from './index';
+} from './index.js';

--- a/packages/csv-stringify/dist/cjs/sync.d.ts
+++ b/packages/csv-stringify/dist/cjs/sync.d.ts
@@ -1,5 +1,5 @@
 
-import { Input, Options } from './index'
+import { Input, Options } from './index.js'
 
 declare function stringify(input: Input, options?: Options): string
 
@@ -9,4 +9,4 @@ export { stringify };
 export {
   RecordDelimiter, Cast, PlainObject, Input, ColumnOption, CastingContext,
   Options
-} from './index';
+} from './index.js';

--- a/packages/csv-stringify/dist/esm/sync.d.ts
+++ b/packages/csv-stringify/dist/esm/sync.d.ts
@@ -1,5 +1,5 @@
 
-import { Input, Options } from './index'
+import { Input, Options } from './index.js'
 
 declare function stringify(input: Input, options?: Options): string
 
@@ -9,4 +9,4 @@ export { stringify };
 export {
   RecordDelimiter, Cast, PlainObject, Input, ColumnOption, CastingContext,
   Options
-} from './index';
+} from './index.js';

--- a/packages/csv-stringify/lib/sync.d.ts
+++ b/packages/csv-stringify/lib/sync.d.ts
@@ -1,5 +1,5 @@
 
-import { Input, Options } from './index'
+import { Input, Options } from './index.js'
 
 declare function stringify(input: Input, options?: Options): string
 
@@ -9,4 +9,4 @@ export { stringify };
 export {
   RecordDelimiter, Cast, PlainObject, Input, ColumnOption, CastingContext,
   Options
-} from './index';
+} from './index.js';

--- a/packages/stream-transform/dist/cjs/sync.d.ts
+++ b/packages/stream-transform/dist/cjs/sync.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="node" />
 
-import { Options } from './index';
+import { Options } from './index.js';
 
 export type Handler<T = any, U = any> = (record: T) => U
 // export default transform;

--- a/packages/stream-transform/dist/esm/sync.d.ts
+++ b/packages/stream-transform/dist/esm/sync.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="node" />
 
-import { Options } from './index';
+import { Options } from './index.js';
 
 export type Handler<T = any, U = any> = (record: T) => U
 // export default transform;

--- a/packages/stream-transform/lib/sync.d.ts
+++ b/packages/stream-transform/lib/sync.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="node" />
 
-import { Options } from './index';
+import { Options } from './index.js';
 
 export type Handler<T = any, U = any> = (record: T) => U
 // export default transform;


### PR DESCRIPTION
Without this change, trying to import this library when using `moduleResolution` `node16` or `nodenext` gives the following error:

```text
node_modules/csv-parse/dist/esm/sync.d.ts:2:25 - error TS2835: Relative import paths need explicit file extensions in EcmaScript imports when '--moduleResolution' is 'node16' or 'nodenext'. Did you mean './index.js'?

2 import { Options } from './index';
                          ~~~~~~~~~

node_modules/csv-parse/dist/esm/sync.d.ts:11:8 - error TS2835: Relative import paths need explicit file extensions in EcmaScript imports when '--moduleResolution' is 'node16' or 'nodenext'. Did you mean './index.js'?

11 } from './index';
          ~~~~~~~~~

node_modules/csv-stringify/dist/esm/sync.d.ts:2:32 - error TS2835: Relative import paths need explicit file extensions in EcmaScript imports when '--moduleResolution' is 'node16' or 'nodenext'. Did you mean './index.js'?

2 import { Input, Options } from './index'
                                 ~~~~~~~~~

node_modules/csv-stringify/dist/esm/sync.d.ts:12:8 - error TS2835: Relative import paths need explicit file extensions in EcmaScript imports when '--moduleResolution' is 'node16' or 'nodenext'. Did you mean './index.js'?

12 } from './index';
          ~~~~~~~~~


Found 4 errors in 2 files.

Errors  Files
     2  node_modules/csv-parse/dist/esm/sync.d.ts:2
     2  node_modules/csv-stringify/dist/esm/sync.d.ts:2
```