### PR TITLE
fix(csv-stringify): add missing type definition for bigint cast option

### DIFF
--- a/packages/csv-stringify/lib/index.d.ts
+++ b/packages/csv-stringify/lib/index.d.ts
@@ -46,6 +46,7 @@ export interface Options extends stream.TransformOptions {
         boolean?: Cast<boolean>
         date?: Cast<Date>
         number?: Cast<number>
+        bigint?: Cast<bigint>
         /**
          * Custom formatter for generic object values
          */


### PR DESCRIPTION
This PR adds the missing bigint type definition for cast options.

I'm not bumping version here - leaving it up to your consideration