### PR TITLE
fix(csv-stringify): update quoted_match confug option to accept arrays

### DIFF
--- a/packages/csv-stringify/dist/cjs/index.d.ts
+++ b/packages/csv-stringify/dist/cjs/index.d.ts
@@ -94,7 +94,7 @@ export interface Options extends stream.TransformOptions {
     /**
      * String or RegExp, no default, quote all fields matching a regular expression.
      */
-    quoted_match?: string | RegExp
+    quoted_match?: string | RegExp | (string | RegExp)[]
     /**
      * Boolean, default to false, quote all fields of type string even if not required.
      */

--- a/packages/csv-stringify/dist/esm/index.d.ts
+++ b/packages/csv-stringify/dist/esm/index.d.ts
@@ -94,7 +94,7 @@ export interface Options extends stream.TransformOptions {
     /**
      * String or RegExp, no default, quote all fields matching a regular expression.
      */
-    quoted_match?: string | RegExp
+    quoted_match?: string | RegExp | (string | RegExp)[]
     /**
      * Boolean, default to false, quote all fields of type string even if not required.
      */

--- a/packages/csv-stringify/lib/index.d.ts
+++ b/packages/csv-stringify/lib/index.d.ts
@@ -94,7 +94,7 @@ export interface Options extends stream.TransformOptions {
     /**
      * String or RegExp, no default, quote all fields matching a regular expression.
      */
-    quoted_match?: string | RegExp
+    quoted_match?: string | RegExp | (string | RegExp)[]
     /**
      * Boolean, default to false, quote all fields of type string even if not required.
      */

--- a/packages/csv-stringify/test/api.types.ts
+++ b/packages/csv-stringify/test/api.types.ts
@@ -116,6 +116,10 @@ describe('API Types', () => {
       const options: Options = {}
       options.quoted_match = "\""
       options.quoted_match = /\"/
+      options.quoted_match = [
+        "\"", 
+        /\"/
+      ]
     })
     
     it('quoted_string', () => {


### PR DESCRIPTION
This pull request updates the type definition for the `quoted_match` config option in csv-stringify to allow for array variants. The support for it is is already there but the types are outdated.