### PR TITLE
test: illustrate commonjs/node16 combo error

### DIFF
--- a/demo/ts-moduleresolution-node16-cjs/lib/stringify.ts
+++ b/demo/ts-moduleresolution-node16-cjs/lib/stringify.ts
@@ -1,0 +1,32 @@
+
+import assert from 'assert'
+import { stringify, Stringifier } from 'csv-stringify';
+
+let output: string = '';
+// Create the parser
+const stringifier: Stringifier = stringify({
+  delimiter: ':',
+  encoding: 'utf8'
+});
+// Use the readable stream api to consume records
+stringifier.on('readable', function(){
+  let record; while ((record = stringifier.read()) !== null) {
+    output += record
+  }
+});
+// Catch any error
+stringifier.on('error', function(err){
+  console.error(err.message)
+});
+// Test that the parsed records matched what's expected
+stringifier.on('end', function(){
+  assert.deepStrictEqual(
+    output,
+    'a:b:c\n1:2:3\n'
+  )
+});
+// Write data to the stream
+stringifier.write(["a", "b", "c"]);
+stringifier.write([1, 2, 3]);
+// Close the readable stream
+stringifier.end();

--- a/demo/ts-moduleresolution-node16-cjs/package.json
+++ b/demo/ts-moduleresolution-node16-cjs/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "csv-demo-ts-moduleresolution-node16-cjs",
+  "version": "0.2.1",
+  "main": "index.js",
+  "license": "MIT",
+  "private": true,
+  "devDependencies": {
+    "typescript": "^4.9.5"
+  },
+  "scripts": {
+    "typecheck": "tsc --noEmit"
+  }
+}

--- a/demo/ts-moduleresolution-node16-cjs/tsconfig.json
+++ b/demo/ts-moduleresolution-node16-cjs/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "compilerOptions": {
+    "esModuleInterop": true,
+    "module": "CommonJS",
+    "moduleResolution": "node16",
+    "strict": true
+  }
+}


### PR DESCRIPTION
Typescript requires commonjs type definitions to have a .cts extension when resolving from package.json exports. Add a demo that illustrates the error.

Based on discussion in #354 