### PR TITLE
feat(csv-stringify): Add escape_formulas to defend against injection attacks

### DIFF
--- a/packages/csv-stringify/lib/api/index.js
+++ b/packages/csv-stringify/lib/api/index.js
@@ -125,7 +125,7 @@ const stringifier = function(options, state, info){
         }else{
           return [Error(`Invalid Casting Value: returned value must return a string, an object, null or undefined, got ${JSON.stringify(value)}`)];
         }
-        const {delimiter, escape, quote, quoted, quoted_empty, quoted_string, quoted_match, record_delimiter} = options;
+        const {delimiter, escape, quote, quoted, quoted_empty, quoted_string, quoted_match, record_delimiter, escape_formulas} = options;
         if('' === value && '' === field){
           let quotedMatch = quoted_match && quoted_match.filter(quoted_match => {
             if(typeof quoted_match === 'string'){
@@ -158,6 +158,9 @@ const stringifier = function(options, state, info){
             }
           });
           quotedMatch = quotedMatch && quotedMatch.length > 0;
+          if (escape_formulas && ['=', '+', '-', '@', '\t', '\r'].includes(value[0])) {
+            value = `'${value}`;
+          }
           const shouldQuote = containsQuote === true || containsdelimiter || containsRecordDelimiter || quoted || quotedString || quotedMatch;
           if(shouldQuote === true && containsEscape === true){
             const regexp = escape === '\\'

--- a/packages/csv-stringify/lib/api/normalize_options.js
+++ b/packages/csv-stringify/lib/api/normalize_options.js
@@ -50,6 +50,12 @@ const normalize_options = function(opts) {
   }else{
     // todo
   }
+  // Normalize option `escape_formulas`
+  if(options.escape_formulas === undefined || options.escape_formulas === null){
+    options.escape_formulas = false;
+  }else{
+    // todo
+  }
   // Normalize option `quoted_empty`
   if(options.quoted_empty === undefined || options.quoted_empty === null){
     options.quoted_empty = undefined;

--- a/packages/csv-stringify/lib/index.d.ts
+++ b/packages/csv-stringify/lib/index.d.ts
@@ -105,6 +105,10 @@ export interface Options extends stream.TransformOptions {
      * defaults to 'auto' (discovered in source or 'unix' if no source is specified).
      */
     record_delimiter?: RecordDelimiter
+    /**
+     * Boolean, default to false, if true, fields that begin with `=`, `+`, `-`, `@`, `\t`, or `\r` will be prepended with a `'` to protected agains csv injection attacks
+     */
+    escape_formulas?: boolean
 }
 
 export class Stringifier extends stream.Transform {

--- a/packages/csv-stringify/test/option.escape_formulas.coffee
+++ b/packages/csv-stringify/test/option.escape_formulas.coffee
@@ -3,7 +3,7 @@ import { stringify } from '../lib/index.js'
 
 describe 'Option `escape_formulas`', ->
 
-  it.only 'should escape =,+,-,@,\t,\r signs', (next) ->
+  it 'should escape =,+,-,@,\t,\r signs', (next) ->
     stringify [
       [ '=a',1]
       [ '+b',2]
@@ -25,7 +25,7 @@ describe 'Option `escape_formulas`', ->
       """
       next()
 
-  it.only 'should first escape_formulas, then quoted', (next) ->
+  it 'should first escape_formulas, then quoted', (next) ->
     stringify [
       [ '=a',1]
       [ 'b',2]

--- a/packages/csv-stringify/test/option.escape_formulas.coffee
+++ b/packages/csv-stringify/test/option.escape_formulas.coffee
@@ -1,0 +1,38 @@
+
+import { stringify } from '../lib/index.js'
+
+describe 'Option `escape_formulas`', ->
+
+  it.only 'should escape =,+,-,@,\t,\r signs', (next) ->
+    stringify [
+      [ '=a',1]
+      [ '+b',2]
+      [ '-c',3]
+      [ '@d',4]
+      [ '\te',5]
+      [ '\rf',6]
+      [ 'g',7]
+    ], escape_formulas: true, eof: false, (err, data) ->
+      return next err if err
+      data.should.eql """
+      '=a,1
+      '+b,2
+      '-c,3
+      '@d,4
+      '\te,5
+      '\rf,6
+      g,7
+      """
+      next()
+
+  it.only 'should first escape_formulas, then quoted', (next) ->
+    stringify [
+      [ '=a',1]
+      [ 'b',2]
+    ], escape_formulas: true, quoted: true, eof: false, (err, data) ->
+      return next err if err
+      data.should.eql """
+      "'=a","1"
+      "b","2"
+      """
+      next()


### PR DESCRIPTION
This PR allows setting simple parameter to defend against CSV injection attacks by adding `escape_formulas` parameter that escapes values that start with `=`, `+`, `-`, `@`, `\t`, or `\r` with a `'`