### PR TITLE
Fix a bug where errors could leak on extremely large stream chunks

### DIFF
--- a/packages/csv-stringify/dist/cjs/index.cjs
+++ b/packages/csv-stringify/dist/cjs/index.cjs
@@ -627,7 +627,16 @@ const stringify = function(){
       callback(err);
     });
     stringifier.on('end', function(){
-      callback(undefined, chunks.join(''));
+      let result;
+      try {
+        result = chunks.join('');
+      } catch (err) {
+        // This can happen if the result is extremely long; it may throw
+        // "Cannot create a string longer than 0x1fffffe8 characters"
+        callback(err);
+        return;
+      }
+      callback(undefined, result);
     });
   }
   if(data !== undefined){

--- a/packages/csv-stringify/dist/esm/index.js
+++ b/packages/csv-stringify/dist/esm/index.js
@@ -5685,7 +5685,16 @@ const stringify = function(){
       callback(err);
     });
     stringifier.on('end', function(){
-      callback(undefined, chunks.join(''));
+      let result;
+      try {
+        result = chunks.join('');
+      } catch (err) {
+        // This can happen if the result is extremely long; it may throw
+        // "Cannot create a string longer than 0x1fffffe8 characters"
+        callback(err);
+        return;
+      }
+      callback(undefined, result);
     });
   }
   if(data !== undefined){

--- a/packages/csv-stringify/dist/iife/index.js
+++ b/packages/csv-stringify/dist/iife/index.js
@@ -5688,7 +5688,16 @@ var csv_stringify = (function (exports) {
         callback(err);
       });
       stringifier.on('end', function(){
-        callback(undefined, chunks.join(''));
+        let result;
+        try {
+          result = chunks.join('');
+        } catch (err) {
+          // This can happen if the result is extremely long; it may throw
+          // "Cannot create a string longer than 0x1fffffe8 characters"
+          callback(err);
+          return;
+        }
+        callback(undefined, result);
       });
     }
     if(data !== undefined){

--- a/packages/csv-stringify/dist/umd/index.js
+++ b/packages/csv-stringify/dist/umd/index.js
@@ -5691,7 +5691,16 @@
         callback(err);
       });
       stringifier.on('end', function(){
-        callback(undefined, chunks.join(''));
+        let result;
+        try {
+          result = chunks.join('');
+        } catch (err) {
+          // This can happen if the result is extremely long; it may throw
+          // "Cannot create a string longer than 0x1fffffe8 characters"
+          callback(err);
+          return;
+        }
+        callback(undefined, result);
       });
     }
     if(data !== undefined){

--- a/packages/csv-stringify/lib/index.js
+++ b/packages/csv-stringify/lib/index.js
@@ -88,7 +88,16 @@ const stringify = function(){
       callback(err);
     });
     stringifier.on('end', function(){
-      callback(undefined, chunks.join(''));
+      let result;
+      try {
+        result = chunks.join('');
+      } catch (err) {
+        // This can happen if the result is extremely long; it may throw
+        // "Cannot create a string longer than 0x1fffffe8 characters"
+        callback(err);
+        return;
+      }
+      callback(undefined, result);
     });
   }
   if(data !== undefined){

--- a/packages/csv/dist/cjs/index.cjs
+++ b/packages/csv/dist/cjs/index.cjs
@@ -267,7 +267,7 @@ let CsvError$1 = class CsvError extends Error {
     if(Array.isArray(message)) message = message.join(' ').trim();
     super(message);
     if(Error.captureStackTrace !== undefined){
-      Error.captureStackTrace(this, CsvError$1);
+      Error.captureStackTrace(this, CsvError);
     }
     this.code = code;
     for(const context of contexts){
@@ -2423,7 +2423,16 @@ const stringify = function(){
       callback(err);
     });
     stringifier.on('end', function(){
-      callback(undefined, chunks.join(''));
+      let result;
+      try {
+        result = chunks.join('');
+      } catch (err) {
+        // This can happen if the result is extremely long; it may throw
+        // "Cannot create a string longer than 0x1fffffe8 characters"
+        callback(err);
+        return;
+      }
+      callback(undefined, result);
     });
   }
   if(data !== undefined){

--- a/packages/csv/dist/cjs/sync.cjs
+++ b/packages/csv/dist/cjs/sync.cjs
@@ -260,7 +260,7 @@ let CsvError$1 = class CsvError extends Error {
     if(Array.isArray(message)) message = message.join(' ').trim();
     super(message);
     if(Error.captureStackTrace !== undefined){
-      Error.captureStackTrace(this, CsvError$1);
+      Error.captureStackTrace(this, CsvError);
     }
     this.code = code;
     for(const context of contexts){

--- a/packages/csv/dist/esm/index.js
+++ b/packages/csv/dist/esm/index.js
@@ -5394,7 +5394,7 @@ let CsvError$1 = class CsvError extends Error {
     if(Array.isArray(message)) message = message.join(' ').trim();
     super(message);
     if(Error.captureStackTrace !== undefined){
-      Error.captureStackTrace(this, CsvError$1);
+      Error.captureStackTrace(this, CsvError);
     }
     this.code = code;
     for(const context of contexts){
@@ -7550,7 +7550,16 @@ const stringify = function(){
       callback(err);
     });
     stringifier.on('end', function(){
-      callback(undefined, chunks.join(''));
+      let result;
+      try {
+        result = chunks.join('');
+      } catch (err) {
+        // This can happen if the result is extremely long; it may throw
+        // "Cannot create a string longer than 0x1fffffe8 characters"
+        callback(err);
+        return;
+      }
+      callback(undefined, result);
     });
   }
   if(data !== undefined){

--- a/packages/csv/dist/esm/sync.js
+++ b/packages/csv/dist/esm/sync.js
@@ -5387,7 +5387,7 @@ let CsvError$1 = class CsvError extends Error {
     if(Array.isArray(message)) message = message.join(' ').trim();
     super(message);
     if(Error.captureStackTrace !== undefined){
-      Error.captureStackTrace(this, CsvError$1);
+      Error.captureStackTrace(this, CsvError);
     }
     this.code = code;
     for(const context of contexts){

--- a/packages/csv/dist/iife/index.js
+++ b/packages/csv/dist/iife/index.js
@@ -5397,7 +5397,7 @@ var csv = (function (exports) {
                 if(Array.isArray(message)) message = message.join(' ').trim();
                 super(message);
                 if(Error.captureStackTrace !== undefined){
-                  Error.captureStackTrace(this, CsvError$1);
+                  Error.captureStackTrace(this, CsvError);
                 }
                 this.code = code;
                 for(const context of contexts){
@@ -7553,7 +7553,16 @@ var csv = (function (exports) {
                   callback(err);
                 });
                 stringifier.on('end', function(){
-                  callback(undefined, chunks.join(''));
+                  let result;
+                  try {
+                    result = chunks.join('');
+                  } catch (err) {
+                    // This can happen if the result is extremely long; it may throw
+                    // "Cannot create a string longer than 0x1fffffe8 characters"
+                    callback(err);
+                    return;
+                  }
+                  callback(undefined, result);
                 });
               }
               if(data !== undefined){

--- a/packages/csv/dist/iife/sync.js
+++ b/packages/csv/dist/iife/sync.js
@@ -5390,7 +5390,7 @@ var csv_sync = (function (exports) {
                 if(Array.isArray(message)) message = message.join(' ').trim();
                 super(message);
                 if(Error.captureStackTrace !== undefined){
-                  Error.captureStackTrace(this, CsvError$1);
+                  Error.captureStackTrace(this, CsvError);
                 }
                 this.code = code;
                 for(const context of contexts){

--- a/packages/csv/dist/umd/index.js
+++ b/packages/csv/dist/umd/index.js
@@ -5400,7 +5400,7 @@
                 if(Array.isArray(message)) message = message.join(' ').trim();
                 super(message);
                 if(Error.captureStackTrace !== undefined){
-                  Error.captureStackTrace(this, CsvError$1);
+                  Error.captureStackTrace(this, CsvError);
                 }
                 this.code = code;
                 for(const context of contexts){
@@ -7556,7 +7556,16 @@
                   callback(err);
                 });
                 stringifier.on('end', function(){
-                  callback(undefined, chunks.join(''));
+                  let result;
+                  try {
+                    result = chunks.join('');
+                  } catch (err) {
+                    // This can happen if the result is extremely long; it may throw
+                    // "Cannot create a string longer than 0x1fffffe8 characters"
+                    callback(err);
+                    return;
+                  }
+                  callback(undefined, result);
                 });
               }
               if(data !== undefined){

--- a/packages/csv/dist/umd/sync.js
+++ b/packages/csv/dist/umd/sync.js
@@ -5393,7 +5393,7 @@
                 if(Array.isArray(message)) message = message.join(' ').trim();
                 super(message);
                 if(Error.captureStackTrace !== undefined){
-                  Error.captureStackTrace(this, CsvError$1);
+                  Error.captureStackTrace(this, CsvError);
                 }
                 this.code = code;
                 for(const context of contexts){


### PR DESCRIPTION
I don't expect a _lot_ of people are going to see this, but we have encountered an issue where an error is thrown as an unhandled exception:

```
Cannot create a string longer than 0x1fffffe8 characters
```

This happens here:

```javascript
    stringifier.on('end', function(){
      callback(undefined, chunks.join(''));
    });
```

Obviously, if `chunks.join()` throws an error, it is leaked rather than passed to the callback. I suppose you don't normally _expect_ `chunks.join()` to fail, but it is in fact posssible.

I'm not sure what style you prefer for this sort of thing; this ought to work and be proof to double-invoking callbacks, but feel free to edit as needed or desired, obviously.