### PR TITLE
Add unicode chars to formula escape

### DIFF
--- a/packages/csv-stringify/dist/cjs/index.cjs
+++ b/packages/csv-stringify/dist/cjs/index.cjs
@@ -483,6 +483,10 @@ const stringifier = function(options, state, info){
             case '@':
             case '\t':
             case '\r':
+            case '\uFF1D': // Unicode '='
+            case '\uFF0B': // Unicode '+'
+            case '\uFF0D': // Unicode '-'
+            case '\uFF20': // Unicode '@'
               value = `'${value}`;
               break;
             }

--- a/packages/csv-stringify/dist/cjs/index.cjs
+++ b/packages/csv-stringify/dist/cjs/index.cjs
@@ -475,8 +475,17 @@ const stringifier = function(options, state, info){
             }
           });
           quotedMatch = quotedMatch && quotedMatch.length > 0;
-          if (escape_formulas && ['=', '+', '-', '@', '\t', '\r'].includes(value[0])) {
-            value = `'${value}`;
+          if (escape_formulas) {
+            switch (value[0]) {
+            case '=':
+            case '+':
+            case '-':
+            case '@':
+            case '\t':
+            case '\r':
+              value = `'${value}`;
+              break;
+            }
           }
           const shouldQuote = containsQuote === true || containsdelimiter || containsRecordDelimiter || quoted || quotedString || quotedMatch;
           if(shouldQuote === true && containsEscape === true){

--- a/packages/csv-stringify/dist/cjs/sync.cjs
+++ b/packages/csv-stringify/dist/cjs/sync.cjs
@@ -473,8 +473,17 @@ const stringifier = function(options, state, info){
             }
           });
           quotedMatch = quotedMatch && quotedMatch.length > 0;
-          if (escape_formulas && ['=', '+', '-', '@', '\t', '\r'].includes(value[0])) {
-            value = `'${value}`;
+          if (escape_formulas) {
+            switch (value[0]) {
+            case '=':
+            case '+':
+            case '-':
+            case '@':
+            case '\t':
+            case '\r':
+              value = `'${value}`;
+              break;
+            }
           }
           const shouldQuote = containsQuote === true || containsdelimiter || containsRecordDelimiter || quoted || quotedString || quotedMatch;
           if(shouldQuote === true && containsEscape === true){

--- a/packages/csv-stringify/dist/cjs/sync.cjs
+++ b/packages/csv-stringify/dist/cjs/sync.cjs
@@ -481,6 +481,10 @@ const stringifier = function(options, state, info){
             case '@':
             case '\t':
             case '\r':
+            case '\uFF1D': // Unicode '='
+            case '\uFF0B': // Unicode '+'
+            case '\uFF0D': // Unicode '-'
+            case '\uFF20': // Unicode '@'
               value = `'${value}`;
               break;
             }

--- a/packages/csv-stringify/dist/esm/index.js
+++ b/packages/csv-stringify/dist/esm/index.js
@@ -5535,14 +5535,18 @@ const stringifier = function(options, state, info){
           quotedMatch = quotedMatch && quotedMatch.length > 0;
           if (escape_formulas) {
             switch (value[0]) {
-              case '=':
-              case '+':
-              case '-':
-              case '@':
-              case '\t':
-              case '\r':
-                value = `'${value}`;
-                break;
+            case '=':
+            case '+':
+            case '-':
+            case '@':
+            case '\t':
+            case '\r':
+            case '\uFF1D': // Unicode '='
+            case '\uFF0B': // Unicode '+'
+            case '\uFF0D': // Unicode '-'
+            case '\uFF20': // Unicode '@'
+              value = `'${value}`;
+              break;
             }
           }
           const shouldQuote = containsQuote === true || containsdelimiter || containsRecordDelimiter || quoted || quotedString || quotedMatch;

--- a/packages/csv-stringify/dist/esm/index.js
+++ b/packages/csv-stringify/dist/esm/index.js
@@ -5533,8 +5533,17 @@ const stringifier = function(options, state, info){
             }
           });
           quotedMatch = quotedMatch && quotedMatch.length > 0;
-          if (escape_formulas && ['=', '+', '-', '@', '\t', '\r'].includes(value[0])) {
-            value = `'${value}`;
+          if (escape_formulas) {
+            switch (value[0]) {
+              case '=':
+              case '+':
+              case '-':
+              case '@':
+              case '\t':
+              case '\r':
+                value = `'${value}`;
+                break;
+            }
           }
           const shouldQuote = containsQuote === true || containsdelimiter || containsRecordDelimiter || quoted || quotedString || quotedMatch;
           if(shouldQuote === true && containsEscape === true){

--- a/packages/csv-stringify/dist/esm/sync.js
+++ b/packages/csv-stringify/dist/esm/sync.js
@@ -2451,6 +2451,10 @@ const stringifier = function(options, state, info){
             case '@':
             case '\t':
             case '\r':
+            case '\uFF1D': // Unicode '='
+            case '\uFF0B': // Unicode '+'
+            case '\uFF0D': // Unicode '-'
+            case '\uFF20': // Unicode '@'
               value = `'${value}`;
               break;
             }

--- a/packages/csv-stringify/dist/esm/sync.js
+++ b/packages/csv-stringify/dist/esm/sync.js
@@ -2443,8 +2443,17 @@ const stringifier = function(options, state, info){
             }
           });
           quotedMatch = quotedMatch && quotedMatch.length > 0;
-          if (escape_formulas && ['=', '+', '-', '@', '\t', '\r'].includes(value[0])) {
-            value = `'${value}`;
+          if (escape_formulas) {
+            switch (value[0]) {
+            case '=':
+            case '+':
+            case '-':
+            case '@':
+            case '\t':
+            case '\r':
+              value = `'${value}`;
+              break;
+            }
           }
           const shouldQuote = containsQuote === true || containsdelimiter || containsRecordDelimiter || quoted || quotedString || quotedMatch;
           if(shouldQuote === true && containsEscape === true){

--- a/packages/csv-stringify/dist/iife/index.js
+++ b/packages/csv-stringify/dist/iife/index.js
@@ -5536,8 +5536,17 @@ var csv_stringify = (function (exports) {
               }
             });
             quotedMatch = quotedMatch && quotedMatch.length > 0;
-            if (escape_formulas && ['=', '+', '-', '@', '\t', '\r'].includes(value[0])) {
-              value = `'${value}`;
+            if (escape_formulas) {
+              switch (value[0]) {
+                case '=':
+                case '+':
+                case '-':
+                case '@':
+                case '\t':
+                case '\r':
+                  value = `'${value}`;
+                  break;
+              }
             }
             const shouldQuote = containsQuote === true || containsdelimiter || containsRecordDelimiter || quoted || quotedString || quotedMatch;
             if(shouldQuote === true && containsEscape === true){

--- a/packages/csv-stringify/dist/iife/index.js
+++ b/packages/csv-stringify/dist/iife/index.js
@@ -5538,14 +5538,18 @@ var csv_stringify = (function (exports) {
             quotedMatch = quotedMatch && quotedMatch.length > 0;
             if (escape_formulas) {
               switch (value[0]) {
-                case '=':
-                case '+':
-                case '-':
-                case '@':
-                case '\t':
-                case '\r':
-                  value = `'${value}`;
-                  break;
+              case '=':
+              case '+':
+              case '-':
+              case '@':
+              case '\t':
+              case '\r':
+              case '\uFF1D': // Unicode '='
+              case '\uFF0B': // Unicode '+'
+              case '\uFF0D': // Unicode '-'
+              case '\uFF20': // Unicode '@'
+                value = `'${value}`;
+                break;
               }
             }
             const shouldQuote = containsQuote === true || containsdelimiter || containsRecordDelimiter || quoted || quotedString || quotedMatch;

--- a/packages/csv-stringify/dist/iife/sync.js
+++ b/packages/csv-stringify/dist/iife/sync.js
@@ -2446,8 +2446,17 @@ var csv_stringify_sync = (function (exports) {
                         }
                       });
                       quotedMatch = quotedMatch && quotedMatch.length > 0;
-                      if (escape_formulas && ['=', '+', '-', '@', '\t', '\r'].includes(value[0])) {
-                        value = `'${value}`;
+                      if (escape_formulas) {
+                        switch (value[0]) {
+                        case '=':
+                        case '+':
+                        case '-':
+                        case '@':
+                        case '\t':
+                        case '\r':
+                          value = `'${value}`;
+                          break;
+                        }
                       }
                       const shouldQuote = containsQuote === true || containsdelimiter || containsRecordDelimiter || quoted || quotedString || quotedMatch;
                       if(shouldQuote === true && containsEscape === true){

--- a/packages/csv-stringify/dist/iife/sync.js
+++ b/packages/csv-stringify/dist/iife/sync.js
@@ -2454,6 +2454,10 @@ var csv_stringify_sync = (function (exports) {
                         case '@':
                         case '\t':
                         case '\r':
+                        case '\uFF1D': // Unicode '='
+                        case '\uFF0B': // Unicode '+'
+                        case '\uFF0D': // Unicode '-'
+                        case '\uFF20': // Unicode '@'
                           value = `'${value}`;
                           break;
                         }

--- a/packages/csv-stringify/dist/umd/index.js
+++ b/packages/csv-stringify/dist/umd/index.js
@@ -5541,14 +5541,18 @@
             quotedMatch = quotedMatch && quotedMatch.length > 0;
             if (escape_formulas) {
               switch (value[0]) {
-                case '=':
-                case '+':
-                case '-':
-                case '@':
-                case '\t':
-                case '\r':
-                  value = `'${value}`;
-                  break;
+              case '=':
+              case '+':
+              case '-':
+              case '@':
+              case '\t':
+              case '\r':
+              case '\uFF1D': // Unicode '='
+              case '\uFF0B': // Unicode '+'
+              case '\uFF0D': // Unicode '-'
+              case '\uFF20': // Unicode '@'
+                value = `'${value}`;
+                break;
               }
             }
             const shouldQuote = containsQuote === true || containsdelimiter || containsRecordDelimiter || quoted || quotedString || quotedMatch;

--- a/packages/csv-stringify/dist/umd/index.js
+++ b/packages/csv-stringify/dist/umd/index.js
@@ -5539,8 +5539,17 @@
               }
             });
             quotedMatch = quotedMatch && quotedMatch.length > 0;
-            if (escape_formulas && ['=', '+', '-', '@', '\t', '\r'].includes(value[0])) {
-              value = `'${value}`;
+            if (escape_formulas) {
+              switch (value[0]) {
+                case '=':
+                case '+':
+                case '-':
+                case '@':
+                case '\t':
+                case '\r':
+                  value = `'${value}`;
+                  break;
+              }
             }
             const shouldQuote = containsQuote === true || containsdelimiter || containsRecordDelimiter || quoted || quotedString || quotedMatch;
             if(shouldQuote === true && containsEscape === true){

--- a/packages/csv-stringify/dist/umd/sync.js
+++ b/packages/csv-stringify/dist/umd/sync.js
@@ -2449,8 +2449,17 @@
                         }
                       });
                       quotedMatch = quotedMatch && quotedMatch.length > 0;
-                      if (escape_formulas && ['=', '+', '-', '@', '\t', '\r'].includes(value[0])) {
-                        value = `'${value}`;
+                      if (escape_formulas) {
+                        switch (value[0]) {
+                        case '=':
+                        case '+':
+                        case '-':
+                        case '@':
+                        case '\t':
+                        case '\r':
+                          value = `'${value}`;
+                          break;
+                        }
                       }
                       const shouldQuote = containsQuote === true || containsdelimiter || containsRecordDelimiter || quoted || quotedString || quotedMatch;
                       if(shouldQuote === true && containsEscape === true){

--- a/packages/csv-stringify/dist/umd/sync.js
+++ b/packages/csv-stringify/dist/umd/sync.js
@@ -2457,6 +2457,10 @@
                         case '@':
                         case '\t':
                         case '\r':
+                        case '\uFF1D': // Unicode '='
+                        case '\uFF0B': // Unicode '+'
+                        case '\uFF0D': // Unicode '-'
+                        case '\uFF20': // Unicode '@'
                           value = `'${value}`;
                           break;
                         }

--- a/packages/csv-stringify/lib/api/index.js
+++ b/packages/csv-stringify/lib/api/index.js
@@ -158,8 +158,17 @@ const stringifier = function(options, state, info){
             }
           });
           quotedMatch = quotedMatch && quotedMatch.length > 0;
-          if (escape_formulas && ['=', '+', '-', '@', '\t', '\r'].includes(value[0])) {
-            value = `'${value}`;
+          if (escape_formulas) {
+            switch (value[0]) {
+            case '=':
+            case '+':
+            case '-':
+            case '@':
+            case '\t':
+            case '\r':
+              value = `'${value}`;
+              break;
+            }
           }
           const shouldQuote = containsQuote === true || containsdelimiter || containsRecordDelimiter || quoted || quotedString || quotedMatch;
           if(shouldQuote === true && containsEscape === true){

--- a/packages/csv-stringify/lib/api/index.js
+++ b/packages/csv-stringify/lib/api/index.js
@@ -166,6 +166,10 @@ const stringifier = function(options, state, info){
             case '@':
             case '\t':
             case '\r':
+            case '\uFF1D': // Unicode '='
+            case '\uFF0B': // Unicode '+'
+            case '\uFF0D': // Unicode '-'
+            case '\uFF20': // Unicode '@'
               value = `'${value}`;
               break;
             }

--- a/packages/csv-stringify/test/option.escape_formulas.coffee
+++ b/packages/csv-stringify/test/option.escape_formulas.coffee
@@ -19,7 +19,7 @@ describe 'Option `escape_formulas`', ->
       code: 'CSV_OPTION_ESCAPE_FORMULAS_INVALID_TYPE'
       message: 'option `escape_formulas` must be a boolean, got "invalid"'
 
-  it 'escape =, +, -, @, \\t, \\r signs', (next) ->
+  it 'escape =, +, -, @, \\t, \\r and unicode equivalent signs', (next) ->
     stringify [
       [ '=a',1]
       [ '+b',2]
@@ -28,6 +28,11 @@ describe 'Option `escape_formulas`', ->
       [ '\te',5]
       [ '\rf',6]
       [ 'g',7]
+      [ '\uFF1Dh',8]
+      [ '\uFF0Bi',9]
+      [ '\uFF0Dj',10]
+      [ '\uFF20k',11]
+      [ '\uFF0Cl',12] # \uFF0C is 'full width comma' and should not be escaped
     ], escape_formulas: true, eof: false, (err, data) ->
       return next err if err
       data.should.eql """
@@ -38,6 +43,11 @@ describe 'Option `escape_formulas`', ->
       '\te,5
       '\rf,6
       g,7
+      '\uFF1Dh,8
+      '\uFF0Bi,9
+      '\uFF0Dj,10
+      '\uFF20k,11
+      \uFF0Cl,12
       """
       next()
 

--- a/packages/csv/dist/cjs/index.cjs
+++ b/packages/csv/dist/cjs/index.cjs
@@ -2271,8 +2271,17 @@ const stringifier = function(options, state, info){
             }
           });
           quotedMatch = quotedMatch && quotedMatch.length > 0;
-          if (escape_formulas && ['=', '+', '-', '@', '\t', '\r'].includes(value[0])) {
-            value = `'${value}`;
+          if (escape_formulas) {
+            switch (value[0]) {
+            case '=':
+            case '+':
+            case '-':
+            case '@':
+            case '\t':
+            case '\r':
+              value = `'${value}`;
+              break;
+            }
           }
           const shouldQuote = containsQuote === true || containsdelimiter || containsRecordDelimiter || quoted || quotedString || quotedMatch;
           if(shouldQuote === true && containsEscape === true){

--- a/packages/csv/dist/cjs/index.cjs
+++ b/packages/csv/dist/cjs/index.cjs
@@ -2279,6 +2279,10 @@ const stringifier = function(options, state, info){
             case '@':
             case '\t':
             case '\r':
+            case '\uFF1D': // Unicode '='
+            case '\uFF0B': // Unicode '+'
+            case '\uFF0D': // Unicode '-'
+            case '\uFF20': // Unicode '@'
               value = `'${value}`;
               break;
             }

--- a/packages/csv/dist/cjs/sync.cjs
+++ b/packages/csv/dist/cjs/sync.cjs
@@ -2056,6 +2056,10 @@ const stringifier = function(options, state, info){
             case '@':
             case '\t':
             case '\r':
+            case '\uFF1D': // Unicode '='
+            case '\uFF0B': // Unicode '+'
+            case '\uFF0D': // Unicode '-'
+            case '\uFF20': // Unicode '@'
               value = `'${value}`;
               break;
             }

--- a/packages/csv/dist/cjs/sync.cjs
+++ b/packages/csv/dist/cjs/sync.cjs
@@ -2048,8 +2048,17 @@ const stringifier = function(options, state, info){
             }
           });
           quotedMatch = quotedMatch && quotedMatch.length > 0;
-          if (escape_formulas && ['=', '+', '-', '@', '\t', '\r'].includes(value[0])) {
-            value = `'${value}`;
+          if (escape_formulas) {
+            switch (value[0]) {
+            case '=':
+            case '+':
+            case '-':
+            case '@':
+            case '\t':
+            case '\r':
+              value = `'${value}`;
+              break;
+            }
           }
           const shouldQuote = containsQuote === true || containsdelimiter || containsRecordDelimiter || quoted || quotedString || quotedMatch;
           if(shouldQuote === true && containsEscape === true){

--- a/packages/csv/dist/esm/index.js
+++ b/packages/csv/dist/esm/index.js
@@ -7406,6 +7406,10 @@ const stringifier = function(options, state, info){
             case '@':
             case '\t':
             case '\r':
+            case '\uFF1D': // Unicode '='
+            case '\uFF0B': // Unicode '+'
+            case '\uFF0D': // Unicode '-'
+            case '\uFF20': // Unicode '@'
               value = `'${value}`;
               break;
             }

--- a/packages/csv/dist/esm/index.js
+++ b/packages/csv/dist/esm/index.js
@@ -7398,8 +7398,17 @@ const stringifier = function(options, state, info){
             }
           });
           quotedMatch = quotedMatch && quotedMatch.length > 0;
-          if (escape_formulas && ['=', '+', '-', '@', '\t', '\r'].includes(value[0])) {
-            value = `'${value}`;
+          if (escape_formulas) {
+            switch (value[0]) {
+            case '=':
+            case '+':
+            case '-':
+            case '@':
+            case '\t':
+            case '\r':
+              value = `'${value}`;
+              break;
+            }
           }
           const shouldQuote = containsQuote === true || containsdelimiter || containsRecordDelimiter || quoted || quotedString || quotedMatch;
           if(shouldQuote === true && containsEscape === true){

--- a/packages/csv/dist/esm/sync.js
+++ b/packages/csv/dist/esm/sync.js
@@ -7183,6 +7183,10 @@ const stringifier = function(options, state, info){
             case '@':
             case '\t':
             case '\r':
+            case '\uFF1D': // Unicode '='
+            case '\uFF0B': // Unicode '+'
+            case '\uFF0D': // Unicode '-'
+            case '\uFF20': // Unicode '@'
               value = `'${value}`;
               break;
             }

--- a/packages/csv/dist/esm/sync.js
+++ b/packages/csv/dist/esm/sync.js
@@ -7175,8 +7175,17 @@ const stringifier = function(options, state, info){
             }
           });
           quotedMatch = quotedMatch && quotedMatch.length > 0;
-          if (escape_formulas && ['=', '+', '-', '@', '\t', '\r'].includes(value[0])) {
-            value = `'${value}`;
+          if (escape_formulas) {
+            switch (value[0]) {
+            case '=':
+            case '+':
+            case '-':
+            case '@':
+            case '\t':
+            case '\r':
+              value = `'${value}`;
+              break;
+            }
           }
           const shouldQuote = containsQuote === true || containsdelimiter || containsRecordDelimiter || quoted || quotedString || quotedMatch;
           if(shouldQuote === true && containsEscape === true){

--- a/packages/csv/dist/iife/index.js
+++ b/packages/csv/dist/iife/index.js
@@ -7409,6 +7409,10 @@ var csv = (function (exports) {
                         case '@':
                         case '\t':
                         case '\r':
+                        case '\uFF1D': // Unicode '='
+                        case '\uFF0B': // Unicode '+'
+                        case '\uFF0D': // Unicode '-'
+                        case '\uFF20': // Unicode '@'
                           value = `'${value}`;
                           break;
                         }

--- a/packages/csv/dist/iife/index.js
+++ b/packages/csv/dist/iife/index.js
@@ -7401,8 +7401,17 @@ var csv = (function (exports) {
                         }
                       });
                       quotedMatch = quotedMatch && quotedMatch.length > 0;
-                      if (escape_formulas && ['=', '+', '-', '@', '\t', '\r'].includes(value[0])) {
-                        value = `'${value}`;
+                      if (escape_formulas) {
+                        switch (value[0]) {
+                        case '=':
+                        case '+':
+                        case '-':
+                        case '@':
+                        case '\t':
+                        case '\r':
+                          value = `'${value}`;
+                          break;
+                        }
                       }
                       const shouldQuote = containsQuote === true || containsdelimiter || containsRecordDelimiter || quoted || quotedString || quotedMatch;
                       if(shouldQuote === true && containsEscape === true){

--- a/packages/csv/dist/iife/sync.js
+++ b/packages/csv/dist/iife/sync.js
@@ -7186,6 +7186,10 @@ var csv_sync = (function (exports) {
                         case '@':
                         case '\t':
                         case '\r':
+                        case '\uFF1D': // Unicode '='
+                        case '\uFF0B': // Unicode '+'
+                        case '\uFF0D': // Unicode '-'
+                        case '\uFF20': // Unicode '@'
                           value = `'${value}`;
                           break;
                         }

--- a/packages/csv/dist/iife/sync.js
+++ b/packages/csv/dist/iife/sync.js
@@ -7178,8 +7178,17 @@ var csv_sync = (function (exports) {
                         }
                       });
                       quotedMatch = quotedMatch && quotedMatch.length > 0;
-                      if (escape_formulas && ['=', '+', '-', '@', '\t', '\r'].includes(value[0])) {
-                        value = `'${value}`;
+                      if (escape_formulas) {
+                        switch (value[0]) {
+                        case '=':
+                        case '+':
+                        case '-':
+                        case '@':
+                        case '\t':
+                        case '\r':
+                          value = `'${value}`;
+                          break;
+                        }
                       }
                       const shouldQuote = containsQuote === true || containsdelimiter || containsRecordDelimiter || quoted || quotedString || quotedMatch;
                       if(shouldQuote === true && containsEscape === true){

--- a/packages/csv/dist/umd/index.js
+++ b/packages/csv/dist/umd/index.js
@@ -7412,6 +7412,10 @@
                         case '@':
                         case '\t':
                         case '\r':
+                        case '\uFF1D': // Unicode '='
+                        case '\uFF0B': // Unicode '+'
+                        case '\uFF0D': // Unicode '-'
+                        case '\uFF20': // Unicode '@'
                           value = `'${value}`;
                           break;
                         }

--- a/packages/csv/dist/umd/index.js
+++ b/packages/csv/dist/umd/index.js
@@ -7404,8 +7404,17 @@
                         }
                       });
                       quotedMatch = quotedMatch && quotedMatch.length > 0;
-                      if (escape_formulas && ['=', '+', '-', '@', '\t', '\r'].includes(value[0])) {
-                        value = `'${value}`;
+                      if (escape_formulas) {
+                        switch (value[0]) {
+                        case '=':
+                        case '+':
+                        case '-':
+                        case '@':
+                        case '\t':
+                        case '\r':
+                          value = `'${value}`;
+                          break;
+                        }
                       }
                       const shouldQuote = containsQuote === true || containsdelimiter || containsRecordDelimiter || quoted || quotedString || quotedMatch;
                       if(shouldQuote === true && containsEscape === true){

--- a/packages/csv/dist/umd/sync.js
+++ b/packages/csv/dist/umd/sync.js
@@ -7181,8 +7181,17 @@
                         }
                       });
                       quotedMatch = quotedMatch && quotedMatch.length > 0;
-                      if (escape_formulas && ['=', '+', '-', '@', '\t', '\r'].includes(value[0])) {
-                        value = `'${value}`;
+                      if (escape_formulas) {
+                        switch (value[0]) {
+                        case '=':
+                        case '+':
+                        case '-':
+                        case '@':
+                        case '\t':
+                        case '\r':
+                          value = `'${value}`;
+                          break;
+                        }
                       }
                       const shouldQuote = containsQuote === true || containsdelimiter || containsRecordDelimiter || quoted || quotedString || quotedMatch;
                       if(shouldQuote === true && containsEscape === true){

--- a/packages/csv/dist/umd/sync.js
+++ b/packages/csv/dist/umd/sync.js
@@ -7189,6 +7189,10 @@
                         case '@':
                         case '\t':
                         case '\r':
+                        case '\uFF1D': // Unicode '='
+                        case '\uFF0B': // Unicode '+'
+                        case '\uFF0D': // Unicode '-'
+                        case '\uFF20': // Unicode '@'
                           value = `'${value}`;
                           break;
                         }


### PR DESCRIPTION
This PR consists of two commits:

- A performance improvement for formula escaping, doing `switch` vs `[].includes` resulted in a 4.5x speed up on my machine (https://jsperf.app/wupoqu)
- Addition of unicode equivalent characters for `=`, `+`, `-`, and `@` in formula escaping