### PR TITLE
fix: fixed CJS types under modern `modernResolution` options

### DIFF
--- a/packages/csv/dist/cjs/index.d.cts
+++ b/packages/csv/dist/cjs/index.d.cts
@@ -1,0 +1,14 @@
+
+// Alias to the modules exposing the stream and callback APIs
+
+import { generate } from 'csv-generate';
+import { parse } from 'csv-parse';
+import { transform } from 'stream-transform';
+import { stringify } from 'csv-stringify';
+
+export { generate, parse, transform, stringify };
+
+export * as generator from 'csv-generate';
+export * as parser from 'csv-parse';
+export * as transformer from 'stream-transform';
+export * as stringifier from 'csv-stringify';

--- a/packages/csv/dist/cjs/sync.d.cts
+++ b/packages/csv/dist/cjs/sync.d.cts
@@ -1,0 +1,14 @@
+
+// Alias to the modules exposing the sync APIs
+
+import { generate } from 'csv-generate/sync'
+import { parse } from 'csv-parse/sync';
+import { transform } from 'stream-transform/sync';
+import { stringify } from 'csv-stringify/sync';
+
+export { generate, parse, transform, stringify }
+
+export * as generator from 'csv-generate/sync';
+export * as parser from 'csv-parse/sync';
+export * as transformer from 'stream-transform/sync';
+export * as stringifier from 'csv-stringify/sync';

--- a/packages/csv/package.json
+++ b/packages/csv/package.json
@@ -48,14 +48,24 @@
   },
   "exports": {
     ".": {
-      "import": "./lib/index.js",
-      "require": "./dist/cjs/index.cjs",
-      "types": "./lib/index.d.ts"
+      "import": {
+        "types": "./lib/index.d.ts",
+        "default": "./lib/index.js"
+      },
+      "require": {
+        "types": "./dist/cjs/index.d.cts",
+        "default": "./dist/cjs/index.cjs"
+      }
     },
     "./sync": {
-      "import": "./lib/sync.js",
-      "require": "./dist/cjs/sync.cjs",
-      "types": "./lib/sync.d.ts"
+      "import": {
+        "types": "./lib/sync.d.ts",
+        "default": "./lib/sync.js"
+      },
+      "require": {
+        "types": "./dist/cjs/sync.d.cts",
+        "default": "./dist/cjs/sync.cjs"
+      }
     },
     "./browser/esm": {
       "types": "./lib/index.d.ts",
@@ -92,7 +102,7 @@
   "scripts": {
     "build": "npm run build:rollup && npm run build:ts",
     "build:rollup": "npx rollup -c",
-    "build:ts": "cp lib/*.ts dist/cjs && cp lib/*.ts dist/esm",
+    "build:ts": "cp lib/index.d.ts dist/cjs/index.d.cts && cp lib/sync.d.ts dist/cjs/sync.d.cts && cp lib/*.ts dist/cjs && cp lib/*.ts dist/esm",
     "lint": "npm run lint:lib && npm run lint:samples && npm run lint:test",
     "lint:lib": "eslint --fix lib/*.js",
     "lint:samples": "eslint --fix samples/*.js",


### PR DESCRIPTION
This is basically the same fix as the one [in this commit](https://github.com/adaltas/node-csv/commit/fa09d03aaf0008b2790656871ca6b2c4be12d14c). That commit didn't fix the situation for the umbrella `csv` package though.

Related to https://github.com/microsoft/TypeScript/issues/50762#issuecomment-1528318260