### PR TITLE
Add `columns` property in `Info` object type

### DIFF
--- a/packages/csv-parse/lib/index.d.ts
+++ b/packages/csv-parse/lib/index.d.ts
@@ -234,6 +234,10 @@ export interface Info {
      * Number of non uniform records when `relax_column_count` is true.
      */
     readonly invalid_field_length: number;
+    /**
+     * Normalized verion of `options.columns` when `options.columns` is true, boolean otherwise.
+     */
+    readonly columns: boolean | { name: string }[];
 }
 
 export type CsvErrorCode = 

--- a/packages/csv-parse/lib/index.d.ts
+++ b/packages/csv-parse/lib/index.d.ts
@@ -237,7 +237,7 @@ export interface Info {
     /**
      * Normalized verion of `options.columns` when `options.columns` is true, boolean otherwise.
      */
-    readonly columns: boolean | { name: string }[];
+    readonly columns: boolean | { name: string }[] | { disabled: true }[];
 }
 
 export type CsvErrorCode = 


### PR DESCRIPTION
According to the [documentation](https://csv.js.org/parse/info/), the `Info` [interface](https://github.com/adaltas/node-csv/blob/master/packages/csv-parse/lib/index.d.ts#L212) should include a `columns` property which returns a `boolean` if `options.columns` is `false` and an Array of normalized `ColumnOption` if `options.columns` is `true.

This should fix the following error when trying to access the `columns` property in the callback
<img width="829" alt="Screenshot 2023-05-23 at 18 00 18" src="https://github.com/adaltas/node-csv/assets/25059869/661a7aa2-9a96-4a9e-b815-e23459adc419">
