### PR TITLE
Return value in cast example

### DIFF
--- a/packages/csv-parse/samples/option.cast.js
+++ b/packages/csv-parse/samples/option.cast.js
@@ -16,8 +16,8 @@ const records = parse(data, {
       // Such as a string
       return `${value}T05:00:00.000Z`;
     }else{
-      // Or the `context` object literal
-      return context;
+      // Or the unmodified value
+      return value;
     }
   },
   trim: true


### PR DESCRIPTION
When I used the "cast" example as-is, I got the error message:

```
CsvError: Option columns missing name: property "name" is required at position 0 when column is an object literal
    at normalize_columns_array (/Users/apickler/rocket/rockethomes/tmp/mls_csv_compare/node_modules/csv-parse/dist/cjs/index.cjs:36:15)
    at Object.__firstLineToColumns (/Users/apickler/rocket/rockethomes/tmp/mls_csv_compare/node_modules/csv-parse/dist/cjs/index.cjs:1067:35)
    at Object.__onRecord (/Users/apickler/rocket/rockethomes/tmp/mls_csv_compare/node_modules/csv-parse/dist/cjs/index.cjs:943:21)
    at Object.parse (/Users/apickler/rocket/rockethomes/tmp/mls_csv_compare/node_modules/csv-parse/dist/cjs/index.cjs:835:40)
    at Parser._transform (/Users/apickler/rocket/rockethomes/tmp/mls_csv_compare/node_modules/csv-parse/dist/cjs/index.cjs:1331:26)
 ```

It would seem to me (and what works for me locally) is that when you don't need to cast a particular column, that you just want to return the unmodified `value`?