### PR TITLE
fix(csv-stringify): allow mixed string and object columns typedef

### DIFF
--- a/packages/csv-stringify/lib/index.d.ts
+++ b/packages/csv-stringify/lib/index.d.ts
@@ -61,7 +61,7 @@ export interface Options extends stream.TransformOptions {
      * can refer to nested properties of the input JSON
      * see the "header" option on how to print columns names on the first line
      */
-    columns?: readonly string[] | PlainObject<string> | readonly ColumnOption[]
+    columns?: ReadonlyArray<string | ColumnOption> | PlainObject<string>
     /**
      * Set the field delimiter, one character only, defaults to a comma.
      */

--- a/packages/csv-stringify/test/api.types.sync.ts
+++ b/packages/csv-stringify/test/api.types.sync.ts
@@ -20,7 +20,7 @@ describe('API Types', () => {
       const rd: RecordDelimiter | undefined = options.record_delimiter
       const cast = options.cast
       const castBoolean : Cast<boolean> | undefined = cast?.boolean
-      const columns: readonly string[] | PlainObject<string> | readonly ColumnOption[] | undefined = options.columns
+      const columns: ReadonlyArray<string | ColumnOption> | PlainObject<string>  | undefined = options.columns
       return [
         rd, castBoolean, columns
       ]

--- a/packages/csv-stringify/test/api.types.ts
+++ b/packages/csv-stringify/test/api.types.ts
@@ -70,6 +70,12 @@ describe('API Types', () => {
         { key: 'b' },
         { key: 'a' }
       ]
+      options.columns = [
+        { key: "b", header: "B" },
+        { key: "a" , header: "A" },
+        "c",
+        { key: "d" },
+      ];
       options.columns = {
         field1: 'column1',
         field3: 'column3'
@@ -81,7 +87,7 @@ describe('API Types', () => {
       options.columns = ["b", "a"];
       options.columns = ["b", "a"] as const;
     });
-    
+
     it('delimiter', () => {
       const options: Options = {}
       options.delimiter = ':'


### PR DESCRIPTION
Since the code allows to specify the `columns` option as a mixed array of either `string` or `ColumnOption`, this updates the types accordingly.

See:
https://github.com/adaltas/node-csv/blob/cc1235a58de98dd9eab0665c7b1d03213e9633c7/packages/csv-stringify/lib/api/normalize_columns.js#L19-L45