### PR TITLE
fix: onRecord accepts a different return type

### DIFF
--- a/packages/csv-parse/lib/index.d.ts
+++ b/packages/csv-parse/lib/index.d.ts
@@ -258,7 +258,7 @@ Note, could not `extends stream.TransformOptions` because encoding can be
 BufferEncoding and undefined as well as null which is not defined in the
 extended type.
 */
-export interface Options<T = string[]> {
+export interface Options<T = string[], U = T> {
   /**
    * If true, the parser will attempt to convert read data types to native types.
    * @deprecated Use {@link cast}
@@ -366,8 +366,8 @@ export interface Options<T = string[]> {
   /**
    * Alter and filter records by executing a user defined function.
    */
-  on_record?: (record: T, context: InfoRecord) => T | null | undefined;
-  onRecord?: (record: T, context: InfoRecord) => T | null | undefined;
+  on_record?: (record: T, context: InfoRecord) => U | null | undefined;
+  onRecord?: (record: T, context: InfoRecord) => U | null | undefined;
   /**
    * Function called when an error occured if the `skip_records_with_error`
    * option is activated.

--- a/packages/csv-parse/lib/sync.d.ts
+++ b/packages/csv-parse/lib/sync.d.ts
@@ -1,13 +1,13 @@
 import { Options } from "./index.js";
 
-type OptionsWithColumns<T> = Omit<Options<T>, "columns"> & {
+type OptionsWithColumns<T, U> = Omit<Options<T>, "columns"> & {
   columns: Exclude<Options["columns"], undefined | false>;
 };
 
-declare function parse<T = unknown>(
+declare function parse<T = unknown, U = T>(
   input: Buffer | string | Uint8Array,
-  options: OptionsWithColumns<T>,
-): T[];
+  options: OptionsWithColumns<T, U>,
+): U[];
 declare function parse(
   input: Buffer | string | Uint8Array,
   options: Options,


### PR DESCRIPTION
this is an attempt to address #461 

it adds a second generic to the `parse` call, with a default type of the same as the first. If you are using `onRecord` to transform, then you define the return type there.