### PR TITLE
chore(csv-stringify): fix typos

### DIFF
--- a/packages/csv-stringify/CHANGELOG.md
+++ b/packages/csv-stringify/CHANGELOG.md
@@ -249,7 +249,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 ## Version 5.6.1
 
 - fix: memory leak in sync
-- refactor: remove unsused values
+- refactor: remove unused values
 - fix: add browserify dev dep
 
 ## Version 5.6.0
@@ -486,7 +486,7 @@ Cleanup
 
 ## Version 2.0.3
 
-- package: es5 backward compatiblity
+- package: es5 backward compatibility
 - package: ignore yarn lock file
 
 ## Version 2.0.2

--- a/packages/csv-stringify/lib/index.d.ts
+++ b/packages/csv-stringify/lib/index.d.ts
@@ -64,7 +64,7 @@ export interface OptionsNormalized extends stream.TransformOptions {
   /**
    * List of fields, applied when `transform` returns an object
    * order matters
-   * read the transformer documentation for additionnal information
+   * read the transformer documentation for additional information
    * columns are auto discovered in the first record when the user write objects
    * can refer to nested properties of the input JSON
    * see the "header" option on how to print columns names on the first line
@@ -114,7 +114,7 @@ export interface OptionsNormalized extends stream.TransformOptions {
    */
   record_delimiter: RecordDelimiter;
   /**
-   * Boolean, default to false, if true, fields that begin with `=`, `+`, `-`, `@`, `\t`, or `\r` will be prepended with a `'` to protected agains csv injection attacks
+   * Boolean, default to false, if true, fields that begin with `=`, `+`, `-`, `@`, `\t`, or `\r` will be prepended with a `'` to protect against csv injection attacks
    */
   escape_formulas: boolean;
 }
@@ -141,7 +141,7 @@ export interface Options extends stream.TransformOptions {
   /**
    * List of fields, applied when `transform` returns an object
    * order matters
-   * read the transformer documentation for additionnal information
+   * read the transformer documentation for additional information
    * columns are auto discovered in the first record when the user write objects
    * can refer to nested properties of the input JSON
    * see the "header" option on how to print columns names on the first line
@@ -191,7 +191,7 @@ export interface Options extends stream.TransformOptions {
    */
   record_delimiter?: RecordDelimiter;
   /**
-   * Boolean, default to false, if true, fields that begin with `=`, `+`, `-`, `@`, `\t`, or `\r` will be prepended with a `'` to protected agains csv injection attacks
+   * Boolean, default to false, if true, fields that begin with `=`, `+`, `-`, `@`, `\t`, or `\r` will be prepended with a `'` to protect against csv injection attacks
    */
   escape_formulas?: boolean;
 }

--- a/packages/csv-stringify/lib/index.js
+++ b/packages/csv-stringify/lib/index.js
@@ -105,7 +105,7 @@ const stringify = function () {
       }
       stringifier.end();
     };
-    // Support Deno, Rollup doesnt provide a shim for setImmediate
+    // Support Deno, Rollup doesn't provide a shim for setImmediate
     if (typeof setImmediate === "function") {
       setImmediate(writer);
     } else {


### PR DESCRIPTION
fix typos in csv-stringify