### PR TITLE
ci: use npm ci with ignored scripts

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -32,6 +32,7 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
       - run: npm ci --ignore-scripts
+      - run: npm rebuild duckdb
       - run: npm run test
   # test_16:
   #   runs-on: ubuntu-latest

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -31,7 +31,7 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
-      - run: npm install
+      - run: npm ci --ignore-scripts
       - run: npm run test
   # test_16:
   #   runs-on: ubuntu-latest
@@ -82,7 +82,7 @@ jobs:
         with:
           node-version: "24.x"
           registry-url: "https://registry.npmjs.org"
-      - run: npm ci
+      - run: npm ci --ignore-scripts
       - run: npm run publish
         # env:
         #   NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## Summary

This updates the publish workflow to make dependency installation more deterministic and reduce lifecycle script execution during CI.

- Use `npm ci --ignore-scripts` instead of `npm install` in the test job
- Keep `npm ci --ignore-scripts` in the publish job
- Explicitly rebuild `duckdb` in the test job because its native binding is required by the existing `csv-issues-esm` tests

## Why

Running npm install commands without `--ignore-scripts` can execute package lifecycle scripts. Using `npm ci --ignore-scripts` limits that behavior and keeps CI installs locked to `package-lock.json`.

The test suite still needs `duckdb/lib/binding/duckdb.node` for `demo/issues-esm/lib/441.js`, so this PR allows only that required native build step explicitly with `npm rebuild duckdb`.