### PR TITLE
fix(csv-stringify): quote fields containing a bare CR or LF

### DIFF
--- a/packages/csv-stringify/lib/api/index.js
+++ b/packages/csv-stringify/lib/api/index.js
@@ -212,6 +212,14 @@ const stringifier = function (options, state, info) {
             value,
             record_delimiter,
           );
+          // `parse` treats CR, LF and CRLF as record delimiters when
+          // `record_delimiter` is left to auto-detection (its default), so a
+          // field holding a bare CR or LF starts a new record and must be
+          // quoted to round-trip, even when it does not contain the configured
+          // `record_delimiter` (eg a lone "\r" stringified with the default
+          // "\n" record delimiter).
+          const containsNewline =
+            value.indexOf("\r") !== -1 || value.indexOf("\n") !== -1;
           const quotedString = quoted_string && typeof field === "string";
           let quotedMatch =
             quoted_match &&
@@ -249,6 +257,7 @@ const stringifier = function (options, state, info) {
             containsQuote === true ||
             containsdelimiter ||
             containsRecordDelimiter ||
+            containsNewline ||
             quoted ||
             quotedString ||
             quotedMatch;

--- a/packages/csv-stringify/test/option.record_delimiter.js
+++ b/packages/csv-stringify/test/option.record_delimiter.js
@@ -31,4 +31,14 @@ describe("Option `record_delimiter`", function () {
       },
     );
   });
+  it("quote a field containing a bare carriage return", function (next) {
+    // `parse` treats a lone CR as a record delimiter under its default
+    // auto-detection, so a field holding a CR must be quoted to round-trip even
+    // though it does not contain the default "\n" record delimiter.
+    stringify([["x\ry", "z"]], { eof: false }, (err, data) => {
+      if (err) return next(err);
+      data.toString().should.eql('"x\ry",z');
+      next();
+    });
+  });
 });


### PR DESCRIPTION
### Problem

`stringify` quotes a field only when it contains the quote, the delimiter, or the configured `record_delimiter` (default `"\n"`). A field that contains a bare carriage return is therefore emitted unquoted, but `parse` treats a lone CR as a record delimiter under its default auto-detection, so the output of `stringify` no longer round-trips through `parse`:

```js
const { stringify } = require("csv-stringify/sync");
const { parse } = require("csv-parse/sync");

const csv = stringify([["x\ry", "z"]]); // "x\ry,z\n", field not quoted
parse(csv); // throws CSV_RECORD_INCONSISTENT_FIELDS_LENGTH
```

A `\n` round-trips because it matches the default `record_delimiter`, and a `\r\n` round-trips because its `\n` matches, but a bare `\r` slips past every check. The same gap applies to a `\n` inside a field when a non-`\n` `record_delimiter` is configured.

### Fix

Quote a field when it contains a CR or LF. `parse` recognizes CR, LF and CRLF as record delimiters in its default auto-detection mode regardless of the delimiter used to write the record, so a field carrying either must be quoted to round-trip. This matches RFC 4180 section 2.6 (fields with line breaks must be enclosed in double quotes) and the behavior of other CSV writers.

Quoting is sufficient, since a quoted field with a CR already round-trips:

```js
parse('"x\ry",z\n'); // [["x\ry", "z"]]
```

### Test

Added a case under `Option record_delimiter` asserting a field with a bare CR is quoted. Reverting the fix makes only that case fail (`expected 'x\ry,z' to equal '"x\ry",z'`); the rest of the `csv-stringify` suite stays green.
