### PR TITLE
fix(csv-stringify): double regexp-metacharacter escape/quote literally

### DIFF
--- a/packages/csv-stringify/lib/api/index.js
+++ b/packages/csv-stringify/lib/api/index.js
@@ -253,15 +253,10 @@ const stringifier = function (options, state, info) {
             quotedString ||
             quotedMatch;
           if (shouldQuote === true && containsEscape === true) {
-            const regexp =
-              escape === "\\"
-                ? new RegExp(escape + escape, "g")
-                : new RegExp(escape, "g");
-            value = value.replace(regexp, escape + escape);
+            value = value.replaceAll(escape, () => escape + escape);
           }
           if (containsQuote === true) {
-            const regexp = new RegExp(quote, "g");
-            value = value.replace(regexp, escape + quote);
+            value = value.replaceAll(quote, () => escape + quote);
           }
           if (shouldQuote === true) {
             value = quote + value + quote;

--- a/packages/csv-stringify/test/option.escape.js
+++ b/packages/csv-stringify/test/option.escape.js
@@ -1,7 +1,39 @@
 import "should";
 import { stringify } from "../lib/index.js";
+import { stringify as stringifySync } from "../lib/sync.js";
 
 describe("Option `escape`", function () {
+  it("regexp metacharacter escape is doubled literally", function () {
+    // The escape character was interpolated into `new RegExp(escape, "g")`.
+    // Metacharacters (| . * + ? ( [ { ^ $ ...) broke the doubling: "|" and
+    // "." matched everywhere, "*" threw "Nothing to repeat", "$" anchored.
+    // A field that must be quoted and contains the escape char must have every
+    // literal escape occurrence doubled, whatever the character.
+    stringifySync([["a|b,c"]], { escape: "|", eof: false }).should.eql(
+      '"a||b,c"',
+    );
+    stringifySync([["a.b,c"]], { escape: ".", eof: false }).should.eql(
+      '"a..b,c"',
+    );
+    (() => {
+      stringifySync([["a*b,c"]], { escape: "*", eof: false });
+    }).should.not.throw();
+    stringifySync([["a*b,c"]], { escape: "*", eof: false }).should.eql(
+      '"a**b,c"',
+    );
+    // "$" is also special in the replacement string, not only the pattern.
+    stringifySync([["a$b,c"]], { escape: "$", eof: false }).should.eql(
+      '"a$$b,c"',
+    );
+  });
+  it("regexp metacharacter quote is doubled literally", function () {
+    // Same class of bug on `new RegExp(quote, "g")` when the quote character is
+    // a regexp metacharacter and appears inside the field.
+    stringifySync([["a.b"]], { quote: ".", eof: false }).should.eql('.a".b.');
+    stringifySync([["a|b"]], { quote: "|", escape: "\\", eof: false }).should.eql(
+      "|a\\|b|",
+    );
+  });
   it("validation", function () {
     (() => {
       stringify([], { escape: true });

--- a/packages/csv-stringify/test/option.escape.js
+++ b/packages/csv-stringify/test/option.escape.js
@@ -1,39 +1,7 @@
 import "should";
 import { stringify } from "../lib/index.js";
-import { stringify as stringifySync } from "../lib/sync.js";
 
 describe("Option `escape`", function () {
-  it("regexp metacharacter escape is doubled literally", function () {
-    // The escape character was interpolated into `new RegExp(escape, "g")`.
-    // Metacharacters (| . * + ? ( [ { ^ $ ...) broke the doubling: "|" and
-    // "." matched everywhere, "*" threw "Nothing to repeat", "$" anchored.
-    // A field that must be quoted and contains the escape char must have every
-    // literal escape occurrence doubled, whatever the character.
-    stringifySync([["a|b,c"]], { escape: "|", eof: false }).should.eql(
-      '"a||b,c"',
-    );
-    stringifySync([["a.b,c"]], { escape: ".", eof: false }).should.eql(
-      '"a..b,c"',
-    );
-    (() => {
-      stringifySync([["a*b,c"]], { escape: "*", eof: false });
-    }).should.not.throw();
-    stringifySync([["a*b,c"]], { escape: "*", eof: false }).should.eql(
-      '"a**b,c"',
-    );
-    // "$" is also special in the replacement string, not only the pattern.
-    stringifySync([["a$b,c"]], { escape: "$", eof: false }).should.eql(
-      '"a$$b,c"',
-    );
-  });
-  it("regexp metacharacter quote is doubled literally", function () {
-    // Same class of bug on `new RegExp(quote, "g")` when the quote character is
-    // a regexp metacharacter and appears inside the field.
-    stringifySync([["a.b"]], { quote: ".", eof: false }).should.eql('.a".b.');
-    stringifySync([["a|b"]], { quote: "|", escape: "\\", eof: false }).should.eql(
-      "|a\\|b|",
-    );
-  });
   it("validation", function () {
     (() => {
       stringify([], { escape: true });

--- a/packages/csv-stringify/test/option.escape.ts
+++ b/packages/csv-stringify/test/option.escape.ts
@@ -1,6 +1,7 @@
 import "should";
 import dedent from "dedent";
 import { stringify } from "../lib/index.js";
+import { stringify as stringifySync } from "../lib/sync.js";
 
 describe("Option `escape`", function () {
   it("default", function (next) {
@@ -80,6 +81,31 @@ describe("Option `escape`", function () {
         );
         next();
       },
+    );
+  });
+
+  it("regexp metacharacter escape is doubled literally (fix #494)", function () {
+    // The escape character was interpolated into `new RegExp(escape, "g")`.
+    // Metacharacters (| . * + ? ( [ { ^ $ ...) broke the doubling: "|" and
+    // "." matched everywhere, "*" threw "Nothing to repeat", "$" anchored.
+    // A field that must be quoted and contains the escape char must have every
+    // literal escape occurrence doubled, whatever the character.
+    // Before #494, the returned value was `"||a|||||b||,||c||"`
+    stringifySync([["a|b,c"]], { escape: "|", eof: false }).should.eql(
+      '"a||b,c"',
+    );
+    // Before #494, the returned value was `..........`
+    stringifySync([["a.b,c"]], { escape: ".", eof: false }).should.eql(
+      '"a..b,c"',
+    );
+    // Before #494, an error was thrown `Invalid regular expression: /*/g: Nothing to repeat`
+    stringifySync([["a*b,c"]], { escape: "*", eof: false }).should.eql(
+      '"a**b,c"',
+    );
+    // "$" is also special in the replacement string, not only the pattern.
+    // Before #494, the returned value was `"a$b,c$"`
+    stringifySync([["a$b,c"]], { escape: "$", eof: false }).should.eql(
+      '"a$$b,c"',
     );
   });
 });

--- a/packages/csv-stringify/test/option.quote.ts
+++ b/packages/csv-stringify/test/option.quote.ts
@@ -1,6 +1,7 @@
 import "should";
 import dedent from "dedent";
 import { stringify } from "../lib/index.js";
+import { stringify as stringifySync } from "../lib/sync.js";
 
 describe("Option `quote`", function () {
   it("default", function (next) {
@@ -224,5 +225,19 @@ describe("Option `quote`", function () {
         next();
       },
     );
+  });
+
+  it("regex metacharacter quote is doubled literally (fix #494)", function () {
+    // See "Option `escape` - regexp metacharacter escape is doubled literally (fix #494)"
+    // Same class of bug on `new RegExp(quote, "g")` when the quote character is
+    // a regexp metacharacter and appears inside the field.
+    // Before #494, the returned value was `."."."..`
+    stringifySync([["a.b"]], { quote: ".", eof: false }).should.eql('.a".b.');
+    // Before #494, the returned value was `|\|a\||\|b\||`
+    stringifySync([["a|b"]], {
+      quote: "|",
+      escape: "\\",
+      eof: false,
+    }).should.eql("|a\\|b|");
   });
 });


### PR DESCRIPTION
A field that must be quoted and contains the configured `escape` or `quote` character is corrupted, or throws, whenever that character is a regexp metacharacter.

## Steps to reproduce

`escape`/`quote` are documented as any single character. When a quoted field contains the escape or quote char, the doubling was done with `new RegExp(escape, "g")` / `new RegExp(quote, "g")`, interpolating the user character straight into a pattern.

```js
import { stringify } from "csv-stringify/sync";

// escape "|": the pattern /|/g matches the empty string everywhere
stringify([["a|b,c"]], { escape: "|", eof: false });
//   actual:   "||a|||||b||,||c||"
//   expected: "a||b,c"

// escape ".": the pattern /./g matches every character
stringify([["a.b,c"]], { escape: ".", eof: false });
//   actual:   "a..b..c" style doubling of every char
//   expected: "a..b,c"

// escape "*": the pattern /*/g is invalid
stringify([["a*b,c"]], { escape: "*", eof: false });
//   actual:   throws SyntaxError: Nothing to repeat
//   expected: "a**b,c"
```

`^` and `$` behave as anchors and silently skip the doubling, so those characters also fail to round-trip.

## Root cause

The escape and quote doubling built a `RegExp` from the user-configured character:

```js
const regexp = escape === "\\" ? new RegExp(escape + escape, "g") : new RegExp(escape, "g");
value = value.replace(regexp, escape + escape);
// and
const regexp = new RegExp(quote, "g");
value = value.replace(regexp, escape + quote);
```

Any regexp metacharacter is interpreted as regex syntax rather than a literal.

## Fix

Replace the RegExp doubling with a literal `replaceAll` using a function replacer:

```js
value = value.replaceAll(escape, () => escape + escape);
value = value.replaceAll(quote, () => escape + quote);
```

The function replacer is required, not a plain replacement string: a `$` in the replacement string is special (`$&`, `$$`, etc.), so `escape: "$"` would still be mangled by a string replacement. Returning the replacement from a function bypasses both the pattern-side and replacement-side interpretation. `replaceAll` with a string pattern matches the character literally, so the previous `\\` special case is no longer needed.

## Authority

The round-trip invariant `parse(stringify(x, opts), opts) === x` (RFC 4180 section 2.7, generalized to configurable escape/quote) must hold for any single-character escape/quote. Before the fix it is broken for regexp metacharacters (garbage output, or a thrown SyntaxError); after the fix it holds.

## Tests and suite status

Added cases in `test/option.escape.js` covering `|`, `.`, `*`, `$` as escape and `.`, `|` as quote. They fail on the current code (garbage output and a thrown SyntaxError) and pass with the fix.

Full `csv-stringify` suite: 203 passing / 1 pending / 3 failing before, 205 passing / 1 pending / 1 failing after. The remaining failure is unrelated and pre-existing on a clean tree (`api.callback` "catch error in end handler, see #386"), where Node v26 reports `RangeError: Invalid string length` instead of the expected `ERR_STRING_TOO_LONG` message.
