### PR TITLE
perf(csv-parse): avoid unnecessary allocation in ResizeableBuffer.toString

### DIFF
--- a/packages/csv-parse/lib/utils/ResizeableBuffer.js
+++ b/packages/csv-parse/lib/utils/ResizeableBuffer.js
@@ -47,7 +47,7 @@ class ResizeableBuffer {
   }
   toString(encoding) {
     if (encoding) {
-      return this.buf.slice(0, this.length).toString(encoding);
+      return this.buf.toString(encoding, 0, this.length);
     } else {
       return Uint8Array.prototype.slice.call(this.buf.slice(0, this.length));
     }


### PR DESCRIPTION
This PR optimises `ResizeableBuffer.toString` in `csv-parse` by avoiding an intermediate sliced Buffer created by `this.buf.slice(...)` and instead passes the bounds directly to `Buffer.toString`.

Although this allocation is a small cost, it adds up given this method is called for each field in the input.

## Benchmarks
### Existing benchmarks
***Take these with a grain of salt - the existing benchmark suite only parses each input file once, making them quite noisy (especially for the smaller inputs)***
| Length | Execution Time (Before) | Execution Time (After) | Throughput (Before) | Throughput (After) | Throughput Improvement |
| :--- | :--- | :--- | :--- | :--- | :--- |
| 20,000 | 0.622 s | 0.356 s | 32,131 op/s | 56,129 op/s | +74.69% |
| 200,000 | 1.563 s | 1.256 s | 127,969 op/s | 159,265 op/s | +24.46% |
| 2,000,000 | 8.498 s | 7.212 s | 235,339 op/s | 277,296 op/s | +17.83% |
| 20,000,000 | 44.022 s | 36.789 s | 454,316 op/s | 543,641 op/s | +19.66% |

### Custom benchmark
To get a more accurate benchmark, I modified the existing benchmark to only test a input file of length 200,000, and took the average of 100 iterations:
0.386769533s before -> 0.340958805s after = ~12% improvement