### PR TITLE
fix(csv-parse): prototype replacement reachable via columns path (#496)

### DIFF
--- a/packages/csv-parse/lib/api/index.js
+++ b/packages/csv-parse/lib/api/index.js
@@ -597,7 +597,7 @@ const transform = function (original_options = {}) {
             // Turn duplicate columns into an array
             if (
               group_columns_by_name === true &&
-              obj[columns[i].name] !== undefined
+              Object.hasOwn(obj, columns[i].name)
             ) {
               if (Array.isArray(obj[columns[i].name])) {
                 obj[columns[i].name] = obj[columns[i].name].concat(record[i]);
@@ -605,7 +605,12 @@ const transform = function (original_options = {}) {
                 obj[columns[i].name] = [obj[columns[i].name], record[i]];
               }
             } else {
-              obj[columns[i].name] = record[i];
+              Object.defineProperty(obj, columns[i].name, {
+                value: record[i],
+                enumerable: true,
+                writable: true,
+                configurable: true,
+              });
             }
           }
           // Without objname (default)

--- a/packages/csv-parse/test/option.columns.ts
+++ b/packages/csv-parse/test/option.columns.ts
@@ -1,4 +1,4 @@
-import "should";
+import should from "should";
 import dedent from "dedent";
 import { parse } from "../lib/index.js";
 import { assert_error } from "./api.assert_error.js";
@@ -428,5 +428,28 @@ describe("Option `columns`", function () {
         },
       );
     });
+  });
+
+  it("prototype replacement still reachable via columns path (#496)", function (next) {
+    parse(
+      "__proto__,__proto__,role\nEVIL1,EVIL2,admin\n",
+      { columns: true, group_columns_by_name: true },
+      (e, recs) => {
+        type evil = {
+          1?: string;
+          2?: string;
+          role?: string;
+        };
+        const rec = recs[0] as evil;
+        JSON.stringify(rec).should.eql(
+          '{"__proto__":["EVIL1","EVIL2"],"role":"admin"}',
+        ); // was equals to `{"role":"admin"}`
+        should((rec as []).length).be.Undefined(); // was equals to `3`
+        should(rec["1"]).be.Undefined(); // was equal to `EVIL1`
+        should(rec["2"]).be.Undefined(); // was equal to `EVIL2`
+        should(rec["role"]).eql("admin"); // was equal to `admin`
+        next();
+      },
+    );
   });
 });


### PR DESCRIPTION
Fixes #496.

The #479 fix guarded only the `objname` collector (`lib/index.js`). The same class of
prototype replacement remained reachable via the `columns` record builder in
`lib/api/index.js`, whose keys come from the CSV header row when `columns: true`.

With `group_columns_by_name: true` and a duplicate `__proto__` column, the duplicate
branch assigned an **array** to `obj['__proto__']`, invoking the `__proto__` setter and
replacing the parsed record's prototype with an attacker-controlled array.

This PR:
- Uses `Object.hasOwn(obj, name)` for the duplicate-column check (so an inherited
  `__proto__` is not treated as already present).
- Assigns via `Object.defineProperty(...)` so a `__proto__` column becomes an ordinary
  own property instead of invoking the setter.
- Adds a regression test in `test/option.columns.ts` covering the `#496` case.

Verified: parsing `__proto__,__proto__,role\nEVIL1,EVIL2,admin` yields
`{"__proto__":["EVIL1","EVIL2"],"role":"admin"}`, the record's prototype is unchanged,
and `rec.length` / `rec["1"]` / `rec["2"]` are `undefined`.

Diff authored by @wdavidw; opening the PR per coordination on #496.