### PR TITLE
fix(csv-stringify): quote every field matching a global quoted_match regexp

### DIFF
--- a/packages/csv-stringify/lib/api/index.js
+++ b/packages/csv-stringify/lib/api/index.js
@@ -18,6 +18,21 @@ const emits_separator = function (value, separator) {
         (value + separator).indexOf(separator) < value.length))
   );
 };
+// True when `value` matches one of the `quoted_match` patterns. The regexps
+// come from the user and the same objects are reused for every field, so the
+// test must not depend on their state: `RegExp.prototype.test` advances
+// `lastIndex` on a global or sticky regexp, which would make a match in one
+// field move where the next field starts matching. `String.prototype.search`
+// searches from the start and restores `lastIndex`, and is equivalent to
+// `test` for the stateless regexps.
+const matches_quoted_match = function (value, quoted_match) {
+  if (!quoted_match) return false;
+  return quoted_match.some((pattern) =>
+    typeof pattern === "string"
+      ? value.indexOf(pattern) !== -1
+      : value.search(pattern) !== -1,
+  );
+};
 
 const stringifier = function (options, state, info) {
   return {
@@ -179,16 +194,7 @@ const stringifier = function (options, state, info) {
           escape_formulas,
         } = options;
         if ("" === value && "" === field) {
-          let quotedMatch =
-            quoted_match &&
-            quoted_match.filter((quoted_match) => {
-              if (typeof quoted_match === "string") {
-                return value.indexOf(quoted_match) !== -1;
-              } else {
-                return quoted_match.test(value);
-              }
-            });
-          quotedMatch = quotedMatch && quotedMatch.length > 0;
+          const quotedMatch = matches_quoted_match(value, quoted_match);
           const shouldQuote =
             quotedMatch ||
             true === quoted_empty ||
@@ -213,16 +219,7 @@ const stringifier = function (options, state, info) {
             record_delimiter,
           );
           const quotedString = quoted_string && typeof field === "string";
-          let quotedMatch =
-            quoted_match &&
-            quoted_match.filter((quoted_match) => {
-              if (typeof quoted_match === "string") {
-                return value.indexOf(quoted_match) !== -1;
-              } else {
-                return quoted_match.test(value);
-              }
-            });
-          quotedMatch = quotedMatch && quotedMatch.length > 0;
+          const quotedMatch = matches_quoted_match(value, quoted_match);
           // See https://github.com/adaltas/node-csv/pull/387
           // More about CSV injection or formula injection, when websites embed
           // untrusted input inside CSV files:

--- a/packages/csv-stringify/test/option.quoted_match.ts
+++ b/packages/csv-stringify/test/option.quoted_match.ts
@@ -49,7 +49,7 @@ describe("Option `quoted_match`", function () {
     );
   });
 
-  it("a global regex matches every field", function (next) {
+  it("a global regex matches every field (fix #498)", function (next) {
     // A global regex carries `lastIndex` from one call to the next, and the
     // same regex object is applied to every field of every record.
     stringify(
@@ -67,7 +67,7 @@ describe("Option `quoted_match`", function () {
     );
   });
 
-  it("a global regex matches every field of a record", function (next) {
+  it("a global regex matches every field of a record (fix #498)", function (next) {
     stringify(
       [["1", "2", "3", "4"]],
       { quoted_match: [/\d/g], eof: false },
@@ -80,7 +80,7 @@ describe("Option `quoted_match`", function () {
     );
   });
 
-  it("a global regex does not consume the caller's `lastIndex`", function (next) {
+  it("a global regex does not consume the caller's `lastIndex` (fix #498)", function (next) {
     const quoted_match = /\d/g;
     quoted_match.lastIndex = 1;
     stringify([["1"], ["2"]], { quoted_match, eof: false }, (err, data) => {

--- a/packages/csv-stringify/test/option.quoted_match.ts
+++ b/packages/csv-stringify/test/option.quoted_match.ts
@@ -49,6 +49,49 @@ describe("Option `quoted_match`", function () {
     );
   });
 
+  it("a global regex matches every field", function (next) {
+    // A global regex carries `lastIndex` from one call to the next, and the
+    // same regex object is applied to every field of every record.
+    stringify(
+      [
+        ["1", "2"],
+        ["3", "4"],
+      ],
+      { quoted_match: /\d/g, eof: false },
+      (err, data) => {
+        if (!err) {
+          data.should.eql('"1","2"\n"3","4"'); // was equal to `"1",2\n"3",4`
+        }
+        next(err);
+      },
+    );
+  });
+
+  it("a global regex matches every field of a record", function (next) {
+    stringify(
+      [["1", "2", "3", "4"]],
+      { quoted_match: [/\d/g], eof: false },
+      (err, data) => {
+        if (!err) {
+          data.should.eql('"1","2","3","4"'); // was equal to `"1",2,"3",4`
+        }
+        next(err);
+      },
+    );
+  });
+
+  it("a global regex does not consume the caller's `lastIndex`", function (next) {
+    const quoted_match = /\d/g;
+    quoted_match.lastIndex = 1;
+    stringify([["1"], ["2"]], { quoted_match, eof: false }, (err, data) => {
+      if (!err) {
+        data.should.eql('"1"\n"2"'); // was equal to `1\n"2"`
+        quoted_match.lastIndex.should.eql(1);
+      }
+      next(err);
+    });
+  });
+
   it('an empty string regex with no other "quoted" options (#344)', function (next) {
     stringify(
       [["a", null, undefined, "", "b"]],


### PR DESCRIPTION
`quoted_match` accepts regexps from the user, and the same regexp objects are reused for every field of every record. They were applied with `RegExp.prototype.test`, which advances `lastIndex` on a global or sticky regexp, so where one field matched decided where the next field started matching:

```js
const { stringify } = require("csv-stringify/sync");

stringify([["1", "2"], ["3", "4"]], { quoted_match: /\d/g });
// '"1",2\n"3",4'       expected '"1","2"\n"3","4"'

stringify([["1", "2", "3", "4"]], { quoted_match: /\d/g });
// '"1",2,"3",4'        expected '"1","2","3","4"'
```

Every matching field is documented — and typed, in `index.d.ts` — as quoted: *"quote all fields matching a regular expression"*. Whether a field gets quoted should not depend on the offset at which the previous one happened to match, and it should not depend on how many times the stringifier has been called: passing the same regexp to two `stringify` calls carries `lastIndex` from the first into the second.

Two things make this easy to miss, and unpleasant when it does bite:

- **It is self-hiding.** A field that does *not* match resets `lastIndex` to 0, so one interleaved non-matching column restores correct behaviour. `quoted_match: [/^0\d+$/g]` over `[["1","01234"],["2","02345"]]` is completely correct, because the `id` column resets the state every row. The bug only shows once matching fields land next to each other, which makes it look data-dependent rather than reproducible.
- **The missed quotes are the ones that were asked for.** `quoted_match` is the mechanism for quoting that the delimiter/quote/record-delimiter checks cannot infer — preserving leading zeros, keeping `1-2` from being read as a date, stopping long digit strings from becoming scientific notation. Dropping it on alternate rows leaves a file that parses fine and means something else in the consumer.

## Fix

Test the patterns with `String.prototype.search`, which searches from the start of the value and restores `lastIndex` afterwards, so the caller's regexp is left as it was found. For the stateless regexps that already worked it is equivalent to `test`.

The two duplicated match blocks are folded into one helper next to `emits_separator`, so they cannot drift apart — the empty-value branch carried the same `test` call. That branch is not observably affected today, since a zero-length match does not advance `lastIndex`, but it is the same expression and now shares the same fix. The helper also drops the intermediate array the `filter` allocated per field.

## Verification

- **No behaviour change for stateless patterns.** Swept the old `test`-based predicate against the new `search`-based one over 1819 pattern/value pairs — 14 non-global regexps and 6 strings, singly and in two-element arrays, against 17 values (empty, unicode, astral, multiline, 50-char) — **0 disagreements**. Repeating one value four times, the old predicate returned inconsistent results in 35 of 119 global/sticky cases, the new one in 0.
- **Three regression tests** in `test/option.quoted_match.ts`, each red before the change with the output noted in a trailing comment: across records, within one record, and one that pre-sets `lastIndex` to show the caller's regexp is no longer consumed. The existing file could not have caught this — every case used a single record and a non-global regexp.
- `npx tsc --noEmit` clean; `packages/csv-stringify` 209 passing / 1 pending, `packages/csv` 25 passing. `prettier --check` and `eslint` clean on both changed files.
- On this machine `api.callback` *"catch error in end handler, see #386"*, `Sample api.async.iterator.js` and the memory-heavy `Sample api.sync.memory.js` also fail on an unmodified `master`, so they are unrelated to this change.

Found while fuzzing the `stringify` → `parse` round trip. Happy to split the helper extraction out of the fix, or to reset `lastIndex` on the caller's regexp instead of using `search`, if you prefer either shape.
