### PR TITLE
fix(csv-parse): type the delimiter_auto score callback arguments

### DIFF
--- a/packages/csv-parse/lib/index.d.ts
+++ b/packages/csv-parse/lib/index.d.ts
@@ -93,9 +93,37 @@ export type ColumnOption<K = string> =
   | false
   | { name: K };
 
+export interface InfoDelimiterAuto {
+  /**
+   * The character code of the delimiter candidate being scored.
+   */
+  readonly char_code: number;
+  /**
+   * The number of occurrences of the candidate in each line.
+   */
+  readonly lines: number[];
+  /**
+   * Whether the candidate is listed in the `preferred` option.
+   */
+  readonly preferred: boolean;
+  /**
+   * The standard deviation of the occurrences across the lines.
+   */
+  readonly std: number;
+  /**
+   * The total number of occurrences of the candidate.
+   */
+  readonly total: number;
+}
+
+export type ScoringFunction = (
+  info: InfoDelimiterAuto,
+  options: OptionDelimiterAuto,
+) => number;
+
 export interface OptionDelimiterAuto {
   preferred: Record<string, number>;
-  score: () => number;
+  score: ScoringFunction;
   size: number;
 }
 

--- a/packages/csv-parse/lib/index.d.ts
+++ b/packages/csv-parse/lib/index.d.ts
@@ -93,7 +93,7 @@ export type ColumnOption<K = string> =
   | false
   | { name: K };
 
-export interface InfoDelimiterAuto {
+export interface ScoringFunctionInfo {
   /**
    * The character code of the delimiter candidate being scored.
    */
@@ -117,11 +117,11 @@ export interface InfoDelimiterAuto {
 }
 
 export type ScoringFunction = (
-  info: InfoDelimiterAuto,
-  options: OptionDelimiterAuto,
+  info: ScoringFunctionInfo,
+  options: ScoringFunctionOptions,
 ) => number;
 
-export interface OptionDelimiterAuto {
+export interface ScoringFunctionOptions {
   preferred: Record<string, number>;
   score: ScoringFunction;
   size: number;
@@ -180,7 +180,7 @@ export interface OptionsNormalized<T = string[], U = T> {
   /**
    * Discover the field delimiter.
    */
-  delimiter_auto: OptionDelimiterAuto;
+  delimiter_auto: ScoringFunctionOptions;
   /**
    * Set the source and destination encoding, a value of `null` returns buffer instead of strings.
    */

--- a/packages/csv-parse/test/option.delimiter_auto.ts
+++ b/packages/csv-parse/test/option.delimiter_auto.ts
@@ -38,6 +38,33 @@ describe("Option `delimiter_auto`", function () {
     ]);
   });
 
+  it("sync custom score", function () {
+    // The default score elects `;` because it is more preferred than `:`
+    parse_sync("a:b;c\nd:e;f", {
+      delimiter_auto: true,
+    }).should.eql([
+      ["a:b", "c"],
+      ["d:e", "f"],
+    ]);
+    // A custom score receives the candidate info and the normalized options
+    const char_codes: number[] = [];
+    parse_sync("a:b;c\nd:e;f", {
+      delimiter_auto: {
+        score: (info, options) => {
+          char_codes.push(info.char_code);
+          return info.char_code === ":".charCodeAt(0)
+            ? 100
+            : (info.total - info.std) *
+                (options.preferred[info.char_code] || 1);
+        },
+      },
+    }).should.eql([
+      ["a", "b;c"],
+      ["d", "e;f"],
+    ]);
+    char_codes.length.should.eql(127);
+  });
+
   it("stream smaller than size", function (next) {
     let content = "";
     for (let i = 0; i < 10; i++) {


### PR DESCRIPTION
`OptionDelimiterAuto.score` is declared as `() => number`, so a custom scoring function cannot be given the two arguments the parser passes it.

```ts
parse(input, {
  delimiter_auto: {
    score: (info, options) =>
      (info.total - info.std) * (options.preferred[info.char_code] || 1),
  },
});
```

Actual, from `npx tsc --noEmit`:

```
error TS2769: No overload matches this call.
    Type '(info: any, options: any) => number' is not assignable to type '() => number'.
      Target signature provides too few arguments. Expected 2 or more, but got 0.
```

Expected: it compiles. `utils/delimiter_discover.js:46` calls `options.score(info, options)`, and the default at `api/normalize_options.js:237` has exactly that shape. The snippet above is a copy of that default, so writing a custom score in TypeScript needs a cast.

`preferred` and `size` went into the interface in the same commit as `score` (4f69946) and both match the runtime. `score` is the member that does not.

This types the callback with a `ScoringFunction` alias sitting next to `CastingFunction`, plus an `InfoDelimiterAuto` interface for the five properties `delimiter_discover` sets before it calls `score`.

The test added to `test/option.delimiter_auto.ts` fails `tsc --noEmit`, which `npm test` runs ahead of mocha, when the type change is reverted. It also covers the runtime path: a custom score that ranks `:` above `;` flips the discovered delimiter on `a:b;c\nd:e;f`, and no test passed a custom score before.
