### PR TITLE
fix(csv-stringify): preserve header cast context when eof is false

### DIFF
--- a/packages/csv-stringify/lib/api/index.js
+++ b/packages/csv-stringify/lib/api/index.js
@@ -290,7 +290,7 @@ const stringifier = function (options, state, info) {
         [err, headers] = this.stringify(headers, true);
         headers += this.options.record_delimiter;
       } else {
-        [err, headers] = this.stringify(headers);
+        [err, headers] = this.stringify(headers, true);
       }
       if (err) return err;
       if (this.options.header_as_comment) {

--- a/packages/csv-stringify/test/option.cast.ts
+++ b/packages/csv-stringify/test/option.cast.ts
@@ -135,25 +135,29 @@ describe("Option `cast`", function () {
       );
     });
 
-    it("header", function (next) {
-      stringify(
-        [["value 1"], ["value 2"]],
-        {
-          header: true,
-          columns: ["header"],
-          cast: {
-            string: (value, context) => `${value} | ${context.header}`,
+    for (const eof of [true, false]) {
+      it(`header with eof ${eof}`, function (next) {
+        stringify(
+          [["value 1"], ["value 2"]],
+          {
+            header: true,
+            columns: ["header"],
+            eof,
+            cast: {
+              string: (value, context) => `${value} | ${context.header}`,
+            },
           },
-        },
-        (err, data) => {
-          if (!err)
-            data
-              .trim()
-              .should.eql("header | true\nvalue 1 | false\nvalue 2 | false");
-          next(err);
-        },
-      );
-    });
+          (err, data) => {
+            if (!err)
+              data.should.eql(
+                "header | true\nvalue 1 | false\nvalue 2 | false" +
+                  (eof ? "\n" : ""),
+              );
+            next(err);
+          },
+        );
+      });
+    }
   });
 
   describe("option header", function () {


### PR DESCRIPTION
With `header: true` and `eof: false`, string cast callbacks receive `context.header === false` for header cells. A formatter that handles headings separately therefore changes behavior when the final newline is disabled:

```js
import { stringify } from "csv-stringify/sync";

stringify([{ name: "alice" }], {
  header: true,
  eof: false,
  cast: {
    string: (value, context) =>
      context.header ? value.toUpperCase() : value,
  },
});
// Before: "name\nalice"
// After:  "NAME\nalice"
```

Pass the header flag in both branches of `headers()`. Parameterize the existing header-context test over both EOF settings and compare exact output, including the trailing delimiter.

Validation on Node 24.19.0:

- Regression fails on the original code and passes with the fix.
- `npm test --workspace=csv-stringify`: TypeScript check passes; 210 passing, 1 existing pending test.
- ESLint passes for both changed files.
- Additional sync/callback checks pass for header-only and populated input with both EOF settings.